### PR TITLE
fix: Elimine BindingResult de endpoint SignUp. #34

### DIFF
--- a/src/main/java/trinity/play2learn/backend/user/controllers/SignUpController.java
+++ b/src/main/java/trinity/play2learn/backend/user/controllers/SignUpController.java
@@ -2,7 +2,6 @@ package trinity.play2learn.backend.user.controllers;
 //Caso de uso 8
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,8 +27,8 @@ public class SignUpController {
     }
 
     @PostMapping
-    public ResponseEntity<BaseResponse<SignUpResponseDto>> signUp(@Valid @RequestBody SignUpRequestDto signUpDto, BindingResult result) {
-        return ResponseFactory.created(signUpService.signUp(signUpDto, result), "Created succesfully");
+    public ResponseEntity<BaseResponse<SignUpResponseDto>> signUp(@Valid @RequestBody SignUpRequestDto signUpDto) {
+        return ResponseFactory.created(signUpService.signUp(signUpDto), "Created succesfully");
     }
 
 }

--- a/src/main/java/trinity/play2learn/backend/user/services/signUp/SignUpService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/signUp/SignUpService.java
@@ -5,9 +5,6 @@ import java.util.Optional;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.BindingResult;
-
-import trinity.play2learn.backend.configs.exceptions.BadRequestException;
 import trinity.play2learn.backend.configs.exceptions.ConflictException;
 import trinity.play2learn.backend.user.dtos.signUp.SignUpRequestDto;
 import trinity.play2learn.backend.user.dtos.signUp.SignUpResponseDto;
@@ -28,11 +25,7 @@ public class SignUpService implements ISignUpService {
     }
 
     @Override
-    public SignUpResponseDto signUp(SignUpRequestDto signUpDto , BindingResult result) {
-    
-        if (result.hasFieldErrors()) {
-            throw new BadRequestException("An error ocurred: ", result.getFieldErrors().stream().map(err -> err.getField() + ": " + err.getDefaultMessage()).toList());
-        }
+    public SignUpResponseDto signUp(SignUpRequestDto signUpDto) {
 
         Optional<User> optionalUser = userRepository.findByEmail(signUpDto.getEmail());
         if (optionalUser.isPresent()) {

--- a/src/main/java/trinity/play2learn/backend/user/services/signUp/interfaces/ISignUpService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/signUp/interfaces/ISignUpService.java
@@ -1,11 +1,9 @@
 package trinity.play2learn.backend.user.services.signUp.interfaces;
 
-import org.springframework.validation.BindingResult;
-
 import trinity.play2learn.backend.user.dtos.signUp.SignUpRequestDto;
 import trinity.play2learn.backend.user.dtos.signUp.SignUpResponseDto;
 
 public interface ISignUpService {
     
-    SignUpResponseDto signUp(SignUpRequestDto signUpDto , BindingResult result);
+    SignUpResponseDto signUp(SignUpRequestDto signUpDto );
 }


### PR DESCRIPTION
Elimine uso de BindingResult en endpoint SignUp, ya que los errores se manejan con el GlobalExceptionHandler