### PR TITLE
51 cambiar el inicio de sesión

### DIFF
--- a/src/main/java/trinity/play2learn/backend/configs/aspects/JwtSessionAspect.java
+++ b/src/main/java/trinity/play2learn/backend/configs/aspects/JwtSessionAspect.java
@@ -38,14 +38,14 @@ public class JwtSessionAspect {
         String authHeader = request.getHeader("Authorization"); //Obtiene el encabezado de autorizacion donde se ubica el token
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            throw new UnauthorizedException("Missing or invalid authentication token.");
+            throw new UnauthorizedException("Missing or invalid authentication access token.");
         }
 
         String jwt = authHeader.substring(7);
 
         //Chequeo que el token no haya expirado
         if (jwtService.isTokenExpired(jwt)) {
-            throw new UnauthorizedException("Token expired.");
+            throw new UnauthorizedException("Access token expired.");
             
         }
 
@@ -54,7 +54,7 @@ public class JwtSessionAspect {
             
         } catch (JwtException e) {
             //Si la firma del token no es valida, lanzo una excepcion.
-            throw new UnauthorizedException("Invalid authentication token.");
+            throw new UnauthorizedException("Invalid authentication access token.");
         }
 
         String requiredRole = sessionRequired.role().toString(); //Obtiene el role requerido para la sesion

--- a/src/main/java/trinity/play2learn/backend/user/controllers/TokenRefreshController.java
+++ b/src/main/java/trinity/play2learn/backend/user/controllers/TokenRefreshController.java
@@ -1,0 +1,28 @@
+package trinity.play2learn.backend.user.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.dtos.token.AccessTokenDto;
+import trinity.play2learn.backend.user.dtos.token.RefreshTokenDto;
+import trinity.play2learn.backend.user.services.jwt.interfaces.IRefreshTokenService;
+
+@RestController
+@RequestMapping("/refresh")
+@AllArgsConstructor
+public class TokenRefreshController {
+    
+    private final IRefreshTokenService refreshTokenService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<AccessTokenDto>> refreshAccessToken(@Valid @RequestBody RefreshTokenDto refreshTokenDto) {
+        return ResponseFactory.ok(refreshTokenService.refreshAccessToken(refreshTokenDto), "Token refreshed successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/user/dtos/login/LoginResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/user/dtos/login/LoginResponseDto.java
@@ -16,5 +16,7 @@ public class LoginResponseDto {
     private Long id;
     private String email;
     private Role role;
-    private String token;
+
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/trinity/play2learn/backend/user/dtos/token/AccessTokenDto.java
+++ b/src/main/java/trinity/play2learn/backend/user/dtos/token/AccessTokenDto.java
@@ -1,0 +1,15 @@
+package trinity.play2learn.backend.user.dtos.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccessTokenDto {
+    
+    private String accessToken;
+}

--- a/src/main/java/trinity/play2learn/backend/user/dtos/token/RefreshTokenDto.java
+++ b/src/main/java/trinity/play2learn/backend/user/dtos/token/RefreshTokenDto.java
@@ -1,0 +1,15 @@
+package trinity.play2learn.backend.user.dtos.token;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class RefreshTokenDto {
+    
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/trinity/play2learn/backend/user/mapper/UserMapper.java
+++ b/src/main/java/trinity/play2learn/backend/user/mapper/UserMapper.java
@@ -24,12 +24,13 @@ public class UserMapper {
             .build();
     }
 
-    public static LoginResponseDto toLoginDto(User user , String token) {
+    public static LoginResponseDto toLoginDto(User user , String accessToken , String refreshToken) {
         return LoginResponseDto.builder()
             .id(user.getId())
             .email(user.getEmail())
             .role(user.getRole())
-            .token(token)
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
             .build();
     }
 

--- a/src/main/java/trinity/play2learn/backend/user/services/jwt/RefreshTokenService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/jwt/RefreshTokenService.java
@@ -1,0 +1,48 @@
+package trinity.play2learn.backend.user.services.jwt;
+
+import org.springframework.stereotype.Service;
+import io.jsonwebtoken.JwtException;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.configs.exceptions.UnauthorizedException;
+import trinity.play2learn.backend.user.dtos.token.AccessTokenDto;
+import trinity.play2learn.backend.user.dtos.token.RefreshTokenDto;
+import trinity.play2learn.backend.user.models.User;
+import trinity.play2learn.backend.user.services.jwt.interfaces.IJwtService;
+import trinity.play2learn.backend.user.services.jwt.interfaces.IRefreshTokenService;
+import trinity.play2learn.backend.user.services.user.interfaces.IUserFindService;
+
+@Service
+@AllArgsConstructor
+public class RefreshTokenService implements IRefreshTokenService {
+
+    private final IJwtService jwtService;
+    private final IUserFindService userFindService;
+
+    @Override
+    public AccessTokenDto refreshAccessToken(RefreshTokenDto refreshTokenDto) {
+
+        String refreshToken = refreshTokenDto.getRefreshToken();
+        if (jwtService.isTokenExpired(refreshToken)) {
+            throw new UnauthorizedException("Refresh token expired.");
+        }
+
+        String email;
+        try {
+            email = jwtService.extractUsername(refreshToken);
+            
+        } catch (JwtException e) { //Si la firma del token es invalida, el metodo extractUsername lanza una excepcion (Que se propaga desde extractAllClaims)
+            throw new UnauthorizedException("Invalid authentication refresh token.");
+        }
+
+        User user = userFindService.findUserByEmail(email);
+        String accessToken = jwtService.generateAccessToken(user);
+
+        AccessTokenDto accessTokenDto = AccessTokenDto
+            .builder()
+            .accessToken(accessToken)
+            .build();
+
+        return accessTokenDto;
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/user/services/jwt/interfaces/IJwtService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/jwt/interfaces/IJwtService.java
@@ -1,20 +1,20 @@
 package trinity.play2learn.backend.user.services.jwt.interfaces;
 
-import java.util.Map;
 
 import org.springframework.security.core.userdetails.UserDetails;
 
 public interface IJwtService {
 
+    String generateAccessToken(UserDetails userDetails);
+
+    String generateRefreshToken(UserDetails userDetails);
+
     String extractUsername(String token);
-
-    String generateToken(UserDetails userDetails);
-
-    String generateToken( Map<String, Object> extraClaims, UserDetails userDetails);
 
     boolean isTokenValid(String token, UserDetails userDetails);
 
     String extractRole(String token);
 
     boolean isTokenExpired(String token);
+    
 }

--- a/src/main/java/trinity/play2learn/backend/user/services/jwt/interfaces/IRefreshTokenService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/jwt/interfaces/IRefreshTokenService.java
@@ -1,0 +1,9 @@
+package trinity.play2learn.backend.user.services.jwt.interfaces;
+
+import trinity.play2learn.backend.user.dtos.token.AccessTokenDto;
+import trinity.play2learn.backend.user.dtos.token.RefreshTokenDto;
+
+public interface IRefreshTokenService {
+    
+    AccessTokenDto refreshAccessToken(RefreshTokenDto refreshTokenDto);
+}

--- a/src/main/java/trinity/play2learn/backend/user/services/login/LoginService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/login/LoginService.java
@@ -23,10 +23,11 @@ public class LoginService implements ILoginService {
 
         User userToLogin = userService.findUserOrThrowException(loginDto.getEmail(), loginDto.getPassword());
 
-        String token = jwtService.generateToken(userToLogin); //El jwtService genera y devuelve el token.
+        String accessToken = jwtService.generateAccessToken(userToLogin); //El jwtService genera y devuelve el access token.
         //El JWT contiene: email, role, issuedAt, expiration
+        String refreshToken = jwtService.generateRefreshToken(userToLogin); //El jwtService genera y devuelve el refresh token.
 
-        return UserMapper.toLoginDto(userToLogin, token);
+        return UserMapper.toLoginDto(userToLogin, accessToken, refreshToken);
     }
      
 }

--- a/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserFindService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserFindService.java
@@ -1,0 +1,22 @@
+package trinity.play2learn.backend.user.services.user.commons;
+
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.configs.exceptions.NotFoundException;
+import trinity.play2learn.backend.user.models.User;
+import trinity.play2learn.backend.user.repository.IUserRepository;
+import trinity.play2learn.backend.user.services.user.interfaces.IUserFindService;
+
+@Service
+@AllArgsConstructor
+public class UserFindService implements IUserFindService {
+    
+    private final IUserRepository userRepository;
+    
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("User not found with email: " + email));
+        
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/user/services/user/interfaces/IUserFindService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/interfaces/IUserFindService.java
@@ -1,0 +1,9 @@
+package trinity.play2learn.backend.user.services.user.interfaces;
+
+import trinity.play2learn.backend.user.models.User;
+
+public interface IUserFindService {
+    
+    User findUserByEmail(String email);
+
+}


### PR DESCRIPTION
## Nueva logica de inicio de sesion con Access y Refresh token
A continuacion, explicare la nueva logica de inicio de sesion implementada:
Al hacer `login` en la aplicacion, el backend devuelve dos tokens en lugar de uno:

![image](https://github.com/user-attachments/assets/212ae985-22b3-4435-832b-67ff90b9ca1c)

El Access token tiene una duracion de **15 minutos** y es el que esperan los endpoints que requieren autorizacion. El Refresh token tiene una duracion de 7 dias y es utilizado para obtener un nuevo access token cuando este expira.
### Refrescar el Access token
Esto se realiza a traves del endpoint `/refresh`, el cual espera un JSON con un unico parametro llamado `refreshToken` y el cual devuelve el nuevo Access token:

![image](https://github.com/user-attachments/assets/9433e304-8c2c-4dd5-81fa-c0d0286d35f1)
