### PR TITLE
66 modificar una materia

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRegisterController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRegisterController.java
@@ -10,8 +10,10 @@ import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectRequestDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectRegisterService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
 import trinity.play2learn.backend.configs.response.BaseResponse;
 import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
 
 @RestController
 @AllArgsConstructor
@@ -21,6 +23,7 @@ public class SubjectRegisterController {
     private final ISubjectRegisterService subjectRegisterService;
 
     @PostMapping
+    @SessionRequired(role = Role.ROLE_ADMIN)
     public ResponseEntity<BaseResponse<SubjectResponseDto>> create(@Valid @RequestBody SubjectRequestDto subjectDto) {
         return ResponseFactory.created(subjectRegisterService.cu28RegisterSubject(subjectDto), "Created succesfully");
     }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectUpdateController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectUpdateController.java
@@ -10,8 +10,10 @@ import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectUpdateService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
 import trinity.play2learn.backend.configs.response.BaseResponse;
 import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
 
 @RestController
 @AllArgsConstructor
@@ -21,6 +23,7 @@ public class SubjectUpdateController {
     private final ISubjectUpdateService subjectService;
 
     @PutMapping
+    @SessionRequired(role = Role.ROLE_ADMIN)
     public ResponseEntity<BaseResponse<SubjectResponseDto>> create(@Valid @RequestBody SubjectUpdateRequestDto subjectDto) {
         return ResponseFactory.created(subjectService.cu29UpdateSubject(subjectDto), "Updated succesfully");
     }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectUpdateController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectUpdateController.java
@@ -1,0 +1,28 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectUpdateService;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/subjects")
+public class SubjectUpdateController {
+    
+    private final ISubjectUpdateService subjectService;
+
+    @PutMapping
+    public ResponseEntity<BaseResponse<SubjectResponseDto>> create(@Valid @RequestBody SubjectUpdateRequestDto subjectDto) {
+        return ResponseFactory.created(subjectService.cu29UpdateSubject(subjectDto), "Updated succesfully");
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/dtos/SubjectUpdateRequestDto.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/dtos/SubjectUpdateRequestDto.java
@@ -1,0 +1,31 @@
+package trinity.play2learn.backend.admin.subject.dtos;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SubjectUpdateRequestDto {
+
+    @NotNull(message = "ID is required.")
+    private Long id;
+    
+    @NotEmpty(message = "Name is required.")
+    @Size(max = 50, message = "Maximum length for name is 50 characters.")
+    @Pattern(regexp = "^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s]+$", message = "Name can only contain letters, numbers, spaces, and the characters áéíóúÁÉÍÓÚñÑ.")
+    private String name;
+
+    @NotNull(message = "Course ID is required.")
+    private Long courseId;
+
+    private Long teacherId; // Opcional
+
+    @NotNull(message = "Optional is required.")
+    private Boolean optional;
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/mappers/SubjectMapper.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/mappers/SubjectMapper.java
@@ -7,6 +7,7 @@ import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectRequestDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
 import trinity.play2learn.backend.admin.subject.models.Subject;
 import trinity.play2learn.backend.admin.teacher.mapper.TeacherMapper;
 import trinity.play2learn.backend.admin.teacher.models.Teacher;
@@ -31,5 +32,16 @@ public class SubjectMapper {
             .teacher(TeacherMapper.toDto(subject.getTeacher()))
             .optional(subject.getOptional())
             .build();
+    }
+
+    public static Subject toUpdateModel(SubjectUpdateRequestDto subjectDto , Course course , Teacher teacher , List<Student> students) {
+        return Subject.builder()
+            .id(subjectDto.getId())
+            .name(subjectDto.getName())
+            .course(course)
+            .teacher(teacher)
+            .students(students)
+            .optional(subjectDto.getOptional())
+            .build();  
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectUpdateService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectUpdateService.java
@@ -1,0 +1,59 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.course.models.Course;
+import trinity.play2learn.backend.admin.course.services.interfaces.ICourseGetByIdService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IGetStudentsByCourse;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectUpdateService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IValidateSubjectService;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.IGetTeacherByIdService;
+
+@Service
+@AllArgsConstructor
+public class SubjectUpdateService implements ISubjectUpdateService {
+
+    private final ICourseGetByIdService courseGetByIdService;
+    private final IGetTeacherByIdService getTeacherByIdService;
+    private final IGetStudentsByCourse courseGetStudentsService;
+    private final ISubjectRepository subjectRepository;
+    private final IValidateSubjectService validateSubjectService;
+
+    @Override
+    public SubjectResponseDto cu29UpdateSubject(SubjectUpdateRequestDto subjectDto) {
+        
+        validateSubjectService.subjectExistById(subjectDto.getId()); //Lanza un NotFoundException si no se encuentra una materia con el ID proporcionado
+
+        Course course = courseGetByIdService.get(subjectDto.getCourseId()); //De no encontrar un curso con el ID proporcionado, lanza una excepción NotFoundException
+        
+        validateSubjectService.subjectExistByNameAndCourse(subjectDto.getName(), course); //Lanza un conflict exception si la materia ya existe en el curso
+
+        Teacher teacher = null;
+        if (subjectDto.getTeacherId() != null) {
+            teacher = getTeacherByIdService.getTeacherById(subjectDto.getTeacherId()); //De no encontrar un profesor con el ID proporcionado, lanza una excepción NotFoundException
+        }
+        //Si no se proporciona un ID de profesor, se establece en null
+
+        List<Student> students = new ArrayList<>(); //Lista vacia
+        if (!subjectDto.getOptional()) {
+            students = courseGetStudentsService.getStudentsByCourseId(subjectDto.getCourseId()); //Si la materia no es opcional, asigno a todos los estudiantes del curso a la misma.
+        }
+        //Si es opcional, no se asignan estudiantes.
+
+        Subject subjectToUpdate = SubjectMapper.toUpdateModel(subjectDto, course, teacher, students);
+
+        return SubjectMapper.toSubjectDto(subjectRepository.save(subjectToUpdate));
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
@@ -1,0 +1,21 @@
+package trinity.play2learn.backend.admin.subject.services.commons;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
+import trinity.play2learn.backend.configs.exceptions.NotFoundException;
+
+@Service
+@AllArgsConstructor
+public class FindSubjectByIdService implements IFindSubjectByIdService {
+    private final ISubjectRepository subjectRepository;
+
+    @Override
+    public Subject findByIdOrThrowException(Long id) {
+        return subjectRepository.findById(id)
+            .orElseThrow(( ) -> new NotFoundException("Subject with id " + id + " does not exist"));
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/ValidateSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/ValidateSubjectService.java
@@ -1,12 +1,12 @@
 package trinity.play2learn.backend.admin.subject.services.commons;
 
 import org.springframework.stereotype.Service;
-
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
 import trinity.play2learn.backend.admin.subject.services.interfaces.IValidateSubjectService;
 import trinity.play2learn.backend.configs.exceptions.ConflictException;
+import trinity.play2learn.backend.configs.exceptions.NotFoundException;
 
 @Service
 @AllArgsConstructor
@@ -19,8 +19,17 @@ public class ValidateSubjectService implements IValidateSubjectService {
 
         if (subjectRepository.existsByNameAndCourse(name, course)) {
             throw new ConflictException("Subject with name " + name + " already exists in course " + course.getYear().getName() + " " +course.getName());
-        };
+        }
             
-        
     }
+
+    @Override
+    public void subjectExistById(Long id) {
+        if (!subjectRepository.existsById(id)) {
+            throw new NotFoundException("Subject with id " + id + " does not exist");
+            
+        }
+    }
+
+    
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/ValidateSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/ValidateSubjectService.java
@@ -6,7 +6,6 @@ import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
 import trinity.play2learn.backend.admin.subject.services.interfaces.IValidateSubjectService;
 import trinity.play2learn.backend.configs.exceptions.ConflictException;
-import trinity.play2learn.backend.configs.exceptions.NotFoundException;
 
 @Service
 @AllArgsConstructor
@@ -22,14 +21,5 @@ public class ValidateSubjectService implements IValidateSubjectService {
         }
             
     }
-
-    @Override
-    public void subjectExistById(Long id) {
-        if (!subjectRepository.existsById(id)) {
-            throw new NotFoundException("Subject with id " + id + " does not exist");
-            
-        }
-    }
-
     
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IFindSubjectByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IFindSubjectByIdService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.subject.models.Subject;
+
+public interface IFindSubjectByIdService {
+    
+    Subject findByIdOrThrowException(Long id);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectUpdateService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectUpdateService.java
@@ -1,0 +1,9 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
+
+public interface ISubjectUpdateService {
+
+    SubjectResponseDto cu29UpdateSubject(SubjectUpdateRequestDto subjectDto);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IValidateSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IValidateSubjectService.java
@@ -5,4 +5,6 @@ import trinity.play2learn.backend.admin.course.models.Course;
 public interface IValidateSubjectService {
     
     void subjectExistByNameAndCourse(String name , Course course);
+
+    void subjectExistById(Long id);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IValidateSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IValidateSubjectService.java
@@ -6,5 +6,4 @@ public interface IValidateSubjectService {
     
     void subjectExistByNameAndCourse(String name , Course course);
 
-    void subjectExistById(Long id);
 }


### PR DESCRIPTION
Cree endpoint para modificar una materia: 

- No podrá haber 2 materias del mismo curso con el mismo nombre.
- El nombre no puede superar los 50 caracteres.
- No se actualiza la lista de estudiantes asignados a la materia mediante este endpoint. La misma sigue igual incluso si la materia pasa de ser opcional a requerida.  Habra otro endpoint para asignar estudiantes a materia. 