### PR TITLE
75 endpoints eliminar y restaurar una materia

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectDeleteController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectDeleteController.java
@@ -1,0 +1,29 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectDeleteService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/subjects")
+public class SubjectDeleteController {
+    
+    private final ISubjectDeleteService subjectDeleteService;
+
+    @DeleteMapping("/{id}")
+    @SessionRequired(role = Role.ROLE_ADMIN)
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
+        subjectDeleteService.cu30DeleteSubject(id);
+        return ResponseFactory.noContent("Deleted successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRestoreController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRestoreController.java
@@ -1,0 +1,26 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectRestoreService;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/subjects")
+public class SubjectRestoreController {
+    
+    private final ISubjectRestoreService subjectRestoreService;
+
+    @PatchMapping("/restore/{id}")
+    public ResponseEntity<BaseResponse<SubjectResponseDto>> restore(@PathVariable Long id) {
+        return ResponseFactory.ok(subjectRestoreService.cu34RestoreSubject(id), "Restored successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
@@ -1,11 +1,15 @@
 package trinity.play2learn.backend.admin.subject.repositories;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.subject.models.Subject;
 
 public interface ISubjectRepository extends CrudRepository<Subject , Long> {
+
+    Optional<Subject> findByIdAndDeletedAtIsNull(Long id);
     
     Boolean existsByNameAndCourse(String name, Course course);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
@@ -11,5 +11,7 @@ public interface ISubjectRepository extends CrudRepository<Subject , Long> {
 
     Optional<Subject> findByIdAndDeletedAtIsNull(Long id);
     
+    Optional<Subject> findByIdAndDeletedAtIsNotNull(Long id);
+    
     Boolean existsByNameAndCourse(String name, Course course);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectDeleteService.java
@@ -1,0 +1,30 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectDeleteService;
+import trinity.play2learn.backend.configs.exceptions.ConflictException;
+
+@Service
+@AllArgsConstructor
+public class SubjectDeleteService implements ISubjectDeleteService {
+    
+    private final IFindSubjectByIdService findSubjectByIdService;
+
+    @Override
+    public void cu30DeleteSubject(Long id) {
+
+        Subject subject = findSubjectByIdService.findByIdOrThrowException(id);
+
+        //No es posible eliminar una materia con estudiantes asociados
+        if (!subject.getStudents().isEmpty()) {
+            throw new ConflictException("Cannot delete subject with ID " + id + " because it has associated students.");
+        }
+
+        subject.delete();
+
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectDeleteService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
 import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectDeleteService;
 import trinity.play2learn.backend.configs.exceptions.ConflictException;
@@ -11,7 +12,7 @@ import trinity.play2learn.backend.configs.exceptions.ConflictException;
 @Service
 @AllArgsConstructor
 public class SubjectDeleteService implements ISubjectDeleteService {
-    
+    private final ISubjectRepository subjectRepository;
     private final IFindSubjectByIdService findSubjectByIdService;
 
     @Override
@@ -26,5 +27,7 @@ public class SubjectDeleteService implements ISubjectDeleteService {
 
         subject.delete();
 
+        subjectRepository.save(subject);
+        
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectRestoreService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectRestoreService.java
@@ -1,0 +1,28 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectRestoreService;
+
+@Service
+@AllArgsConstructor
+public class SubjectRestoreService implements ISubjectRestoreService{
+    
+    private final ISubjectRepository subjectRepository;
+    private final IFindSubjectByIdService findSubjectByIdService;
+
+    @Override
+    public SubjectResponseDto cu34RestoreSubject(Long id) {
+        Subject subject = findSubjectByIdService.findDeletedById(id);
+
+        subject.restore();
+        
+        return SubjectMapper.toSubjectDto(subjectRepository.save(subject));
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
@@ -18,4 +18,13 @@ public class FindSubjectByIdService implements IFindSubjectByIdService {
         return subjectRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(( ) -> new NotFoundException("Subject with id " + id + " does not exist"));
     }
+
+    @Override
+    public Subject findDeletedById(Long id) {
+        return subjectRepository.findByIdAndDeletedAtIsNotNull(id).orElseThrow(
+            () -> new NotFoundException("Subject with id " + id + " does not exist or is not eliminated")
+        );
+    }
+
+    
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/FindSubjectByIdService.java
@@ -15,7 +15,7 @@ public class FindSubjectByIdService implements IFindSubjectByIdService {
 
     @Override
     public Subject findByIdOrThrowException(Long id) {
-        return subjectRepository.findById(id)
+        return subjectRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(( ) -> new NotFoundException("Subject with id " + id + " does not exist"));
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IFindSubjectByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/IFindSubjectByIdService.java
@@ -5,4 +5,6 @@ import trinity.play2learn.backend.admin.subject.models.Subject;
 public interface IFindSubjectByIdService {
     
     Subject findByIdOrThrowException(Long id);
+
+    Subject findDeletedById(Long id);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectDeleteService.java
@@ -1,0 +1,5 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+public interface ISubjectDeleteService {
+    void cu30DeleteSubject(Long id);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectRestoreService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectRestoreService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+
+public interface ISubjectRestoreService {
+    
+    SubjectResponseDto cu34RestoreSubject(Long id);
+}


### PR DESCRIPTION
Cree dos endpoints:
- Delete Subject
- Restore Subject.

En base a estos criterios de aceptacion de Gestionar materia: 
- Se debe poder eliminar una materia que no tenga estudiantes asociados.
- Se debe poder restaurar una materia eliminada.
