### PR TITLE
feat: Listar docentes devuelvo todos, no solo los activos. #88

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/teacher/dtos/TeacherResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/dtos/TeacherResponseDto.java
@@ -22,4 +22,5 @@ public class TeacherResponseDto {
 
     private UserResponseDto user;
 
+    private boolean active;
 }

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/mapper/TeacherMapper.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/mapper/TeacherMapper.java
@@ -31,6 +31,7 @@ public class TeacherMapper {
                 .lastname(teacher.getLastname())
                 .dni(teacher.getDni())
                 .user(UserMapper.toUserDto(teacher.getUser()))
+                .active(teacher.getDeletedAt() == null)
                 .build();
     }
 

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/repositories/ITeacherRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/repositories/ITeacherRepository.java
@@ -1,6 +1,5 @@
 package trinity.play2learn.backend.admin.teacher.repositories;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import trinity.play2learn.backend.admin.teacher.models.Teacher;
@@ -14,7 +13,5 @@ public interface ITeacherRepository extends CrudRepository<Teacher,Long> {
     Boolean existsByDniAndIdNot(String dni, Long id);
 
     Boolean existsByDni(String dni);
-
-    List<Teacher> findAllByDeletedAtIsNull();
 
 }

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherListPaginatedService.java
@@ -35,7 +35,7 @@ public class TeacherListPaginatedService implements ITeacherListPaginatedService
         List<String> filterValues) {
         
         Pageable pageable = PaginatorUtils.buildPageable(page, size, orderBy, orderType);
-        Specification<Teacher> spec = Specification.where(TeacherSpecs.notDeleted());
+        Specification<Teacher> spec = Specification.where(null); //Quite reestriccion notDeleted
         
         if (search != null && !search.isBlank()) {
         spec = spec.and(TeacherSpecs.nameOrLastnameContains(search));

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherListService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherListService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.teacher.dtos.TeacherResponseDto;
 import trinity.play2learn.backend.admin.teacher.mapper.TeacherMapper;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
 import trinity.play2learn.backend.admin.teacher.repositories.ITeacherRepository;
 import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherListService;
 
@@ -18,6 +19,7 @@ public class TeacherListService implements ITeacherListService {
 
     @Override
     public List<TeacherResponseDto> cu25ListTeachers() {
-        return TeacherMapper.toListDto(teacherRepository.findAllByDeletedAtIsNull());
+
+        return TeacherMapper.toListDto( (List<Teacher>) teacherRepository.findAll()); //Casteo a de iterable a List
     }
 }


### PR DESCRIPTION
Cambie endpoint listar docentes y listar docentes con paginacion para que devuelvan los docentes activos y dados de baja. Ademas, agregue el atributo `active` en el dto que devuelven los endpoints