### PR TITLE
100 eliminar y restaurar un docente

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.CrudRepository;
 
 import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
 
 public interface ISubjectRepository extends CrudRepository<Subject , Long> {
 
@@ -17,4 +18,7 @@ public interface ISubjectRepository extends CrudRepository<Subject , Long> {
     Boolean existsByNameAndCourse(String name, Course course);
 
     List<Subject> findAllByDeletedAtIsNull();
+
+
+    boolean existsByTeacher(Teacher teacher);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/TeacherInSubjectsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/TeacherInSubjectsService.java
@@ -1,0 +1,23 @@
+package trinity.play2learn.backend.admin.subject.services.commons;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ITeacherInSubjectsService;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.configs.exceptions.ConflictException;
+
+@Service
+@AllArgsConstructor
+public class TeacherInSubjectsService implements  ITeacherInSubjectsService{
+    
+    private final ISubjectRepository subjectRepository;
+
+    @Override
+    public void validate(Teacher teacher) { //Valida si un profesor esta asociado a alguna materia
+        if (subjectRepository.existsByTeacher(teacher)) {
+            throw new ConflictException("Teacher with ID " + teacher.getId() + " is associated with a subject.");
+        };
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ITeacherInSubjectsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ITeacherInSubjectsService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+
+public interface ITeacherInSubjectsService {
+    
+    void validate(Teacher teacher); //Buscar si el estudiante esta asignado a alguna materia
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/controllers/TeacherDeleteController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/controllers/TeacherDeleteController.java
@@ -1,0 +1,30 @@
+package trinity.play2learn.backend.admin.teacher.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherDeleteService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/teachers")
+public class TeacherDeleteController {
+    
+    private final ITeacherDeleteService teacherDeleteService;
+
+    @DeleteMapping("/{id}")
+    @SessionRequired(roles = {Role.ROLE_ADMIN})
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long id) {
+
+        teacherDeleteService.cu24DeleteTeacher(id);
+        return ResponseFactory.noContent("Deleted successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/controllers/TeacherRestoreController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/controllers/TeacherRestoreController.java
@@ -1,0 +1,29 @@
+package trinity.play2learn.backend.admin.teacher.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.teacher.dtos.TeacherResponseDto;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherRestoreService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/teachers")
+public class TeacherRestoreController {
+    
+    private final ITeacherRestoreService teacherRestoreService;
+
+    @PatchMapping("/restore/{id}")
+    @SessionRequired(roles = {Role.ROLE_ADMIN})
+    public ResponseEntity<BaseResponse<TeacherResponseDto>> restore(@PathVariable Long id) {
+
+        return ResponseFactory.ok(teacherRestoreService.cu35RestoreTeacher(id), "Restored successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/models/Teacher.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/models/Teacher.java
@@ -48,10 +48,12 @@ public class Teacher {
 
     public void delete () {
         this.deletedAt = LocalDateTime.now();
+        user.delete(); //Al eliminar al docente, tambien se elimina a su usuario
     }
 
     public void restore () {
         this.deletedAt = null;
+        user.restore(); //Al restaurar al docente, tambien se restaura a su usuario
     }
 
 }

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/repositories/ITeacherRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/repositories/ITeacherRepository.java
@@ -9,6 +9,8 @@ public interface ITeacherRepository extends CrudRepository<Teacher,Long> {
     
     Optional<Teacher> findByIdAndDeletedAtIsNull(Long id);
 
+    Optional<Teacher> findByIdAndDeletedAtIsNotNull(Long id);
+
 
     //Busca si existe un profesor distinto del pasado por id con el mismo dni.
     Boolean existsByDniAndIdNot(String dni, Long id);

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherDeleteService.java
@@ -1,0 +1,32 @@
+package trinity.play2learn.backend.admin.teacher.services;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ITeacherInSubjectsService;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.admin.teacher.repositories.ITeacherRepository;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.IGetTeacherByIdService;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherDeleteService;
+
+@Service
+@AllArgsConstructor
+public class TeacherDeleteService implements ITeacherDeleteService {
+    
+    private final ITeacherRepository teacherRepository;
+    private final IGetTeacherByIdService getTeacherByIdService;
+    private final ITeacherInSubjectsService teacherInSubjectsService;
+
+    @Override
+    public void cu24DeleteTeacher(Long id) {
+
+        Teacher teacher = getTeacherByIdService.getTeacherById(id); //Lanza un 404 si no encuentra un docente con el id proporcionado
+
+        teacherInSubjectsService.validate(teacher); //Valida si un profesor esta asociado a alguna materia
+
+        teacher.delete();
+
+        teacherRepository.save(teacher);
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherRestoreService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/TeacherRestoreService.java
@@ -1,0 +1,31 @@
+package trinity.play2learn.backend.admin.teacher.services;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.teacher.dtos.TeacherResponseDto;
+import trinity.play2learn.backend.admin.teacher.mapper.TeacherMapper;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.admin.teacher.repositories.ITeacherRepository;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.IGetTeacherByIdService;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherRestoreService;
+
+@Service
+@AllArgsConstructor
+public class TeacherRestoreService implements ITeacherRestoreService{
+    
+    private final ITeacherRepository teacherRepository;
+    private final IGetTeacherByIdService getTeacherByIdService;
+
+    @Override
+    public TeacherResponseDto cu35RestoreTeacher(Long id) {
+
+        Teacher teacher = getTeacherByIdService.getEliminatedTeacherById(id);
+
+        teacher.restore();
+
+        return TeacherMapper.toDto(teacherRepository.save(teacher));
+    }
+    
+
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/commons/GetTeacherByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/commons/GetTeacherByIdService.java
@@ -20,4 +20,13 @@ public class GetTeacherByIdService implements IGetTeacherByIdService {
         return teacherRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(() -> new NotFoundException("Teacher not found with id: " + id));
     }
+
+    @Override
+    public Teacher getEliminatedTeacherById(Long id) {
+
+        return teacherRepository.findByIdAndDeletedAtIsNotNull(id)
+            .orElseThrow(() -> new NotFoundException("Teacher not found or not eliminated with id: " + id));
+    }
+
+    
 }

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/IGetTeacherByIdService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/IGetTeacherByIdService.java
@@ -5,4 +5,6 @@ import trinity.play2learn.backend.admin.teacher.models.Teacher;
 public interface IGetTeacherByIdService {
     
     Teacher getTeacherById(Long id);
+
+    Teacher getEliminatedTeacherById(Long id);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/ITeacherDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/ITeacherDeleteService.java
@@ -1,0 +1,5 @@
+package trinity.play2learn.backend.admin.teacher.services.interfaces;
+
+public interface ITeacherDeleteService {
+    void cu24DeleteTeacher(Long id);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/ITeacherRestoreService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/teacher/services/interfaces/ITeacherRestoreService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.teacher.services.interfaces;
+
+import trinity.play2learn.backend.admin.teacher.dtos.TeacherResponseDto;
+
+public interface ITeacherRestoreService {
+    
+    TeacherResponseDto cu35RestoreTeacher(Long id);
+}

--- a/src/main/java/trinity/play2learn/backend/user/models/User.java
+++ b/src/main/java/trinity/play2learn/backend/user/models/User.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -30,6 +31,9 @@ public class User implements UserDetails {
 
     private Role role;
 
+    @Column(nullable = true)
+    private LocalDateTime deletedAt;
+
     @Override
     public boolean isAccountNonExpired() { return true; } 
     @Override
@@ -48,5 +52,12 @@ public class User implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name())); 
     }
-    
+
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore(){
+        this.deletedAt = null;
+    }
 }


### PR DESCRIPTION
Cree dos enpoints:
- Uno para eliminar logicamente a un docente
   - Devuelve 404 si el id proporcionado no pertenece a un docente activo
   - Devuelve 401 si el docente esta asignado a alguna materia
   - Elimina al usuario asociado al docente
- Otro para restaurar al docente
   - Devuelve un 404 si el id proporcionado no pertenece a un docente eliminado
   - Restaura al usuario asociado al docente
 