### PR TITLE
69 endpoint para asignar estudiantes a una materia

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/student/dtos/StudentSimplificatedResponse.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/dtos/StudentSimplificatedResponse.java
@@ -1,0 +1,16 @@
+package trinity.play2learn.backend.admin.student.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class StudentSimplificatedResponse { //DTO de respuesta simplificado de estudiante
+    
+    private Long id;
+    private String name;
+    private String lastname;
+    private String dni;
+}

--- a/src/main/java/trinity/play2learn/backend/admin/student/mappers/StudentMapper.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/mappers/StudentMapper.java
@@ -1,9 +1,12 @@
 package trinity.play2learn.backend.admin.student.mappers;
 
+import java.util.List;
+
 import trinity.play2learn.backend.admin.course.mappers.CourseMapper;
 import trinity.play2learn.backend.admin.course.models.Course;
 import trinity.play2learn.backend.admin.student.dtos.StudentRequestDto;
 import trinity.play2learn.backend.admin.student.dtos.StudentResponseDto;
+import trinity.play2learn.backend.admin.student.dtos.StudentSimplificatedResponse;
 import trinity.play2learn.backend.admin.student.dtos.StudentUpdateRequestDto;
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.user.mapper.UserMapper;
@@ -42,5 +45,21 @@ public class StudentMapper {
             .user(model.getUser())
             .deletedAt(model.getDeletedAt())
             .build();
+    }
+
+    public static StudentSimplificatedResponse toSimplificatedDto (Student student) {
+        return StudentSimplificatedResponse.builder()
+            .id(student.getId())
+            .name(student.getName())
+            .lastname(student.getLastname())
+            .dni(student.getDni())
+            .build();
+    }
+
+    public static List<StudentSimplificatedResponse> toSimplificatedDtos (List<Student> students) {
+        return students
+            .stream()
+            .map(student -> toSimplificatedDto(student))
+            .toList();
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/student/services/commons/StudentsGetByListService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/services/commons/StudentsGetByListService.java
@@ -1,0 +1,25 @@
+package trinity.play2learn.backend.admin.student.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByIdService;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentsGetByListService;
+
+@Service
+@AllArgsConstructor
+public class StudentsGetByListService implements IStudentsGetByListService{
+    
+    private final IStudentGetByIdService studentGetByIdService;
+
+    @Override
+    public List<Student> getStudentsByIdList(List<Long> studentIds) {
+        return studentIds
+            .stream()
+            .map(studentGetByIdService::get)
+            .toList();
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/student/services/interfaces/IStudentsGetByListService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/services/interfaces/IStudentsGetByListService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.admin.student.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IStudentsGetByListService {
+    
+    List<Student> getStudentsByIdList(List<Long> studentIds);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAddStudentsController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAddStudentsController.java
@@ -1,0 +1,29 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAddStudentsService;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/subjects")
+public class SubjectAddStudentsController {
+    
+    private final ISubjectAddStudentsService subjectAddStudentsService;
+
+    @PatchMapping("/add-students/{subjectId}")
+    public ResponseEntity<BaseResponse<SubjectAddResponseDto>> addStudents(@PathVariable Long subjectId, @RequestBody List<Long> studentIds) {
+        return ResponseFactory.ok(subjectAddStudentsService.add(subjectId, studentIds), "Students added successfully");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/dtos/SubjectAddResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/dtos/SubjectAddResponseDto.java
@@ -1,0 +1,19 @@
+package trinity.play2learn.backend.admin.subject.dtos;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import trinity.play2learn.backend.admin.student.dtos.StudentSimplificatedResponse;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SubjectAddResponseDto {
+    
+    private Long id;
+    private String subjectName;
+    private String courseName;
+    private List<StudentSimplificatedResponse> students;
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/mappers/SubjectMapper.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/mappers/SubjectMapper.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import trinity.play2learn.backend.admin.course.mappers.CourseMapper;
 import trinity.play2learn.backend.admin.course.models.Course;
+import trinity.play2learn.backend.admin.student.mappers.StudentMapper;
 import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectRequestDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectUpdateRequestDto;
@@ -49,5 +51,14 @@ public class SubjectMapper {
         return subjects.stream()
             .map(SubjectMapper::toSubjectDto)
             .toList();
+    }
+
+    public static SubjectAddResponseDto toAddDto(Subject subject) {
+        return SubjectAddResponseDto.builder()
+            .id(subject.getId())
+            .subjectName(subject.getName())
+            .courseName(subject.getCourse().getYear().getName() + " " + subject.getCourse().getName())
+            .students(StudentMapper.toSimplificatedDtos(subject.getStudents()))
+            .build();
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectAddStudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectAddStudentsService.java
@@ -1,0 +1,42 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentsGetByListService;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAddStudentsService;
+
+@Service
+@AllArgsConstructor
+public class SubjectAddStudentsService implements ISubjectAddStudentsService {
+    
+    private final ISubjectRepository subjectRepository;
+    private final IFindSubjectByIdService subjectGetService;
+
+    private final IStudentsGetByListService studentsGetByListService;
+    @Override
+    public SubjectAddResponseDto add(Long subjectId, List<Long> studentIds) {
+
+        Subject subject = subjectGetService.findByIdOrThrowException(subjectId); //Lanza un 404 si la materia no existe (o esta eliminada) 
+
+        List<Student> studentsToAdd = studentsGetByListService.getStudentsByIdList(studentIds); //Lanza un 404 si alguno de los estudiantes de la lista no existe (O esta eliminado)
+        
+        //Este for es para evitar añadir estudiantes que ya estan asignados a la materia
+        for (Student student : studentsToAdd) {
+            if (!subject.getStudents().contains(student)) {
+                subject.getStudents().add(student);
+            } 
+        }
+
+        return SubjectMapper.toAddDto(subjectRepository.save(subject));
+
+    }
+
+    
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectAddStudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectAddStudentsService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+
+public interface ISubjectAddStudentsService {
+    
+    SubjectAddResponseDto add(Long subjectId, List<Long> studentIds); ;
+}


### PR DESCRIPTION
Cree un endpoint que recibe una lista de ids de estudiantes y los asigna a la materia proporcionada mediante id en la url. 

- Devuelve un 404 si la materia no existe o fue eliminada
- Devuelve un 404 si algun estudiante de la lista no existe o fue eliminado.
- Devuelve un 200 ok y añade los estudiantes a la materia. 
Si se quiere añadir un estudiante que ya esta asignado a la materia, no se devolvera ningun error, simplemente no se lo asignara nuevamente. 

Ademas, cree un DTO para devolver los estudiantes asignados a la materia de manera mas simplificada (Sin la informacion de su curso). 