### PR TITLE
feat: Cree endpoint para desasignar estudiantes de una materia. #70

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRemoveStudentsController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectRemoveStudentsController.java
@@ -1,0 +1,29 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectRemoveStudentsService;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("admin/subjects")
+public class SubjectRemoveStudentsController {
+    
+    private final ISubjectRemoveStudentsService subjectRemoveStudentsService;
+
+    @PatchMapping("remove-students/{subjectId}")
+    public ResponseEntity<BaseResponse<SubjectAddResponseDto>> remove(@PathVariable Long subjectId , @RequestBody List<Long> studentIds) {
+
+        return ResponseFactory.ok(subjectRemoveStudentsService.cu37RemoveStudentsFromSubject(subjectId , studentIds), "Students removed from subject"); 
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/models/Subject.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/models/Subject.java
@@ -75,4 +75,8 @@ public class Subject {
     public void restore () {
         this.deletedAt = null;
     }
+
+    public void removeStudents(List<Student> studentsToRemove) {
+        this.students.removeAll(studentsToRemove);
+    }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectRemoveStudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectRemoveStudentsService.java
@@ -1,0 +1,39 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.repositories.IStudentRepository;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByListService;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.IFindSubjectByIdService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectRemoveStudentsService;
+
+@Service
+@AllArgsConstructor
+public class SubjectRemoveStudentsService implements ISubjectRemoveStudentsService {
+    
+    private final ISubjectRepository subjectRepository;
+    private final IFindSubjectByIdService findSubjectByIdService;
+   private final IStudentGetByListService studentListService;
+
+    @Override
+    public SubjectAddResponseDto cu37RemoveStudentsFromSubject(Long subjectId, List<Long> studentIds) {
+
+        Subject subject = findSubjectByIdService.findByIdOrThrowException(subjectId); //Lanza un 404 si no encuentra la materia con el id proporcionado
+
+        List<Student> studentsToRemove = studentListService.getStudentsByIdList(studentIds); //Lanza un 404 si no encuentra algun estudiante con el id proporcionado
+
+        subject.removeStudents(studentsToRemove); //Remueve los estudiantes de la materia
+
+        return SubjectMapper.toAddDto(subjectRepository.save(subject));
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectRemoveStudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectRemoveStudentsService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
+
+public interface ISubjectRemoveStudentsService {
+    
+    SubjectAddResponseDto cu37RemoveStudentsFromSubject(Long subjectId, List<Long> studentIds);
+}


### PR DESCRIPTION
Cree un endpoint que recibe el ID de una materia y un listado de IDs de estudiantes a desasignar de la materia. 
- Devuelve 404 si no encuentra una materia con el ID proporcionado
- Devuelve 404 si no encuentra algun estudiante de la lista con los IDs proporcionados.
- Desasigna los estudiantes de la materia y devuelve un DTO de materia.

