### PR TITLE
89 validar usuario activo mediante notacion

### DIFF
--- a/src/main/java/trinity/play2learn/backend/user/repository/IUserRepository.java
+++ b/src/main/java/trinity/play2learn/backend/user/repository/IUserRepository.java
@@ -10,6 +10,7 @@ import trinity.play2learn.backend.user.models.User;
 @Repository
 public interface IUserRepository extends CrudRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
     boolean existsByEmailAndDeletedAtIsNull(String email);
  

--- a/src/main/java/trinity/play2learn/backend/user/repository/IUserRepository.java
+++ b/src/main/java/trinity/play2learn/backend/user/repository/IUserRepository.java
@@ -11,5 +11,6 @@ import trinity.play2learn.backend.user.models.User;
 public interface IUserRepository extends CrudRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndDeletedAtIsNull(String email);
+ 
 }

--- a/src/main/java/trinity/play2learn/backend/user/services/login/LoginService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/login/LoginService.java
@@ -20,8 +20,9 @@ public class LoginService implements ILoginService {
     //Valida el email y la contraseña y devuelve el token del usuario si todo es correcto.
     @Override
     public LoginResponseDto login(LoginRequestDto loginDto) {
-
-        User userToLogin = userService.findUserOrThrowException(loginDto.getEmail(), loginDto.getPassword());
+ 
+        User userToLogin = userService.findUserOrThrowException(loginDto.getEmail(), loginDto.getPassword()); 
+        //Devuelve UnauthorizedException si no encuentra al usuario o si la contraseña es incorrecta
 
         String accessToken = jwtService.generateAccessToken(userToLogin); //El jwtService genera y devuelve el access token.
         //El JWT contiene: email, role, issuedAt, expiration

--- a/src/main/java/trinity/play2learn/backend/user/services/user/UserService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/UserService.java
@@ -5,30 +5,26 @@ import org.springframework.stereotype.Service;
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.configs.exceptions.UnauthorizedException;
 import trinity.play2learn.backend.user.models.User;
-import trinity.play2learn.backend.user.repository.IUserRepository;
+import trinity.play2learn.backend.user.services.user.interfaces.IUserFindService;
 import trinity.play2learn.backend.user.services.user.interfaces.IUserService;
 
 @Service
 @AllArgsConstructor
 public class UserService implements IUserService {
-    private final IUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final IUserFindService userFindService;
 
-    private final String UNAUTHORIZED_MESSAGE = "Email or password is incorrect";
+    private final String UNAUTHORIZED_MESSAGE = "Invalid credentials or unauthorized access.";
 
     //Devuelve el usuario si existe y la contraseña es correcta. De lo contrario lanza una excepcion.
     @Override
     public User findUserOrThrowException(String email, String password) {
 
-        User user = findUserOrThrowException(email);
+        User user = userFindService.findUserByEmail(email); //Devuelve UnauthorizedException si no encuentra al usuario
 
         checkIfPasswordMatchesOrThrowException(password, user.getPassword());
        
         return user;
-    }
-
-    private User findUserOrThrowException(String email) {
-        return userRepository.findByEmail(email).orElseThrow(() -> new UnauthorizedException(UNAUTHORIZED_MESSAGE));
     }
 
     private void checkIfPasswordMatchesOrThrowException(String loginPassword, String dbPassword) {

--- a/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserActiveValidation.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserActiveValidation.java
@@ -1,0 +1,22 @@
+package trinity.play2learn.backend.user.services.user.commons;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.configs.exceptions.UnauthorizedException;
+import trinity.play2learn.backend.user.services.user.interfaces.IUserActiveValidation;
+import trinity.play2learn.backend.user.services.user.interfaces.IUserExistService;
+
+@Service
+@AllArgsConstructor
+public class UserActiveValidation implements IUserActiveValidation{
+    
+    private final IUserExistService userExistService;
+
+    @Override
+    public void validateIfUserIsActive(String email) {
+        if (!userExistService.validate(email)) {
+            throw new UnauthorizedException("User not valid or unauthorized.");
+        };
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserExistsService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserExistsService.java
@@ -13,7 +13,7 @@ public class UserExistsService implements IUserExistService {
 
     @Override
     public boolean validate(String email) {
-        return userRepository.existsByEmail(email);
+        return userRepository.existsByEmailAndDeletedAtIsNull(email);
     }
     
 }

--- a/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserFindService.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/commons/UserFindService.java
@@ -2,7 +2,7 @@ package trinity.play2learn.backend.user.services.user.commons;
 
 import org.springframework.stereotype.Service;
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.configs.exceptions.NotFoundException;
+import trinity.play2learn.backend.configs.exceptions.UnauthorizedException;
 import trinity.play2learn.backend.user.models.User;
 import trinity.play2learn.backend.user.repository.IUserRepository;
 import trinity.play2learn.backend.user.services.user.interfaces.IUserFindService;
@@ -12,10 +12,11 @@ import trinity.play2learn.backend.user.services.user.interfaces.IUserFindService
 public class UserFindService implements IUserFindService {
     
     private final IUserRepository userRepository;
-    
+    private final String UNAUTHORIZED_MESSAGE = "Invalid credentials or unauthorized access.";
+
     public User findUserByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundException("User not found with email: " + email));
+        return userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(() -> new UnauthorizedException(UNAUTHORIZED_MESSAGE));
         
     }
     

--- a/src/main/java/trinity/play2learn/backend/user/services/user/interfaces/IUserActiveValidation.java
+++ b/src/main/java/trinity/play2learn/backend/user/services/user/interfaces/IUserActiveValidation.java
@@ -1,0 +1,5 @@
+package trinity.play2learn.backend.user.services.user.interfaces;
+
+public interface IUserActiveValidation {
+    void validateIfUserIsActive(String email);
+}


### PR DESCRIPTION
Agregue una validacion en el filtro que intercepta a la notacion SessionRequired- 
La misma valida que el usuario del JWT que realiza la peticion este activo (No eliminado) en la base de datos. De lo contrario devuelve un 401. 
