### PR TITLE
138 Endpoints para asignar y desasignar docente a materia

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAddStudentsController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAddStudentsController.java
@@ -1,14 +1,12 @@
 package trinity.play2learn.backend.admin.subject.controllers;
 
 import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectAddResponseDto;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAddStudentsService;
@@ -27,7 +25,7 @@ public class SubjectAddStudentsController {
     public ResponseEntity<BaseResponse<SubjectAddResponseDto>> addStudents(@PathVariable Long subjectId, @RequestBody List<Long> studentIds) {
         return ResponseFactory.ok(
             subjectAddStudentsService.cu36AddStudentsToSubject(subjectId, studentIds), 
-            SuccessfulMessages.SUBJECT_ADD_STUDENTS_SUCCESSFULLY
+            SuccessfulMessages.SUBJECT_ASSIGN_TEACHER_SUCCESFULLY
         );
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAssignTeacherController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAssignTeacherController.java
@@ -1,0 +1,26 @@
+package trinity.play2learn.backend.admin.subject.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAssignTeacherService;
+import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/admin/subjects")
+public class SubjectAssignTeacherController {
+    
+    private final ISubjectAssignTeacherService subjectAssignTeacherService;
+
+    @PatchMapping("/assign-teacher/{subjectId}/{teacherId}")
+    public ResponseEntity<BaseResponse<SubjectResponseDto>> assignTeacher(@PathVariable Long subjectId,@PathVariable Long teacherId) {
+        return ResponseFactory.ok( subjectAssignTeacherService.cu49AssignTeacher(subjectId, teacherId), SuccessfulMessages.createdSuccessfully());
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAssignTeacherController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/controllers/SubjectAssignTeacherController.java
@@ -8,9 +8,12 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAssignTeacherService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectUnassignTeacherService;
+import trinity.play2learn.backend.configs.aspects.SessionRequired;
 import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
 import trinity.play2learn.backend.configs.response.BaseResponse;
 import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
 
 @RestController
 @AllArgsConstructor
@@ -18,9 +21,18 @@ import trinity.play2learn.backend.configs.response.ResponseFactory;
 public class SubjectAssignTeacherController {
     
     private final ISubjectAssignTeacherService subjectAssignTeacherService;
+    private final ISubjectUnassignTeacherService subjectUnassignTeacherService;
+
 
     @PatchMapping("/assign-teacher/{subjectId}/{teacherId}")
+    @SessionRequired(roles = {Role.ROLE_ADMIN})
     public ResponseEntity<BaseResponse<SubjectResponseDto>> assignTeacher(@PathVariable Long subjectId,@PathVariable Long teacherId) {
-        return ResponseFactory.ok( subjectAssignTeacherService.cu49AssignTeacher(subjectId, teacherId), SuccessfulMessages.createdSuccessfully());
+        return ResponseFactory.ok( subjectAssignTeacherService.cu49AssignTeacher(subjectId, teacherId), SuccessfulMessages.SUBJECT_ASSIGN_TEACHER_SUCCESFULLY);
+    }
+
+    @PatchMapping("/unassign-teacher/{subjectId}")
+    @SessionRequired(roles = {Role.ROLE_ADMIN})
+    public ResponseEntity<BaseResponse<SubjectResponseDto>> unassignTeacher(@PathVariable Long subjectId) {
+        return ResponseFactory.ok( subjectUnassignTeacherService.cu50UnassignTeacher(subjectId), SuccessfulMessages.SUBJECT_UNASSIGN_TEACHER_SUCCESFULLY);
     }
 }

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectAssignTeacherService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectAssignTeacherService.java
@@ -1,0 +1,37 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectAssignTeacherService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectGetByIdService;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherGetByIdService;
+
+@Service
+@AllArgsConstructor
+public class SubjectAssignTeacherService implements ISubjectAssignTeacherService {
+    
+    private final ISubjectRepository subjectRepository;
+    private final ISubjectGetByIdService getSubjectByIdService;
+    private final ITeacherGetByIdService getTeacherByIdService;
+
+    @Override
+    @Transactional
+    public SubjectResponseDto cu49AssignTeacher(Long subjectId, Long teacherId) {
+        
+        Subject subject = getSubjectByIdService.findById(subjectId);
+
+        Teacher teacher = getTeacherByIdService.findById(teacherId);
+
+        subject.setTeacher(teacher);
+        
+        return SubjectMapper.toSubjectDto(subjectRepository.save(subject));
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectUnassignTeacherService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/SubjectUnassignTeacherService.java
@@ -1,0 +1,31 @@
+package trinity.play2learn.backend.admin.subject.services;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.admin.subject.mappers.SubjectMapper;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+import trinity.play2learn.backend.admin.subject.repositories.ISubjectRepository;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectGetByIdService;
+import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectUnassignTeacherService;
+
+@Service
+@AllArgsConstructor
+public class SubjectUnassignTeacherService implements ISubjectUnassignTeacherService{
+    
+    private final ISubjectRepository subjectRepository;
+    private final ISubjectGetByIdService getSubjectByIdService;
+
+    @Override
+    @Transactional
+    public SubjectResponseDto cu50UnassignTeacher(Long subjectId) {
+    
+        Subject subject = getSubjectByIdService.findById(subjectId);
+        
+        subject.setTeacher(null);
+        
+        return SubjectMapper.toSubjectDto(subjectRepository.save(subject));
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectAssignTeacherService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectAssignTeacherService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+
+public interface ISubjectAssignTeacherService {
+    
+    SubjectResponseDto cu49AssignTeacher(Long subjectId, Long teacherId);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectUnassignTeacherService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/interfaces/ISubjectUnassignTeacherService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.admin.subject.services.interfaces;
+
+import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+
+public interface ISubjectUnassignTeacherService {
+    
+    SubjectResponseDto cu50UnassignTeacher(Long subjectId);
+}

--- a/src/main/java/trinity/play2learn/backend/configs/messages/SuccessfulMessages.java
+++ b/src/main/java/trinity/play2learn/backend/configs/messages/SuccessfulMessages.java
@@ -41,6 +41,9 @@ public class SuccessfulMessages {
     public static final String SUBJECT_ADD_STUDENTS_SUCCESSFULLY = "Estudiantes agregado con exito";
     public static final String SUBJECT_REMOVE_STUDENTS_SUCCESSFULLY = "Estudiantes removidos con exito";
 
+    public static final String SUBJECT_ASSIGN_TEACHER_SUCCESFULLY = "Profesor asignado con exito";
+    public static final String SUBJECT_UNASSIGN_TEACHER_SUCCESFULLY = "Profesor desasignado con exito";
+
     public static final String loginSuccessfully() {
         return "Logueado correctamente";
     }


### PR DESCRIPTION
### Asignar docente a materia
El endpoint para asignar un docente a una materia se accede mediante la URL: `/admin/subjects/assign-teacher/{subject_id}/{teacher_id}`
El endpoint validara que tanto la materia como el docente existan y, de ser asi, asignara al docente a la materia. Ya sea que la materia no tenga ningun docente asignado, tenga otro, o tenga ya el mismo que se esta queriendo asignar, se devolvera un 200 ok.

### Desasignar docente a materia
El endpoint se accede mediante la url `/admin/subjects/unassign-teacher/{subject_id}`
El endpoint validara que la materia exista y, de ser asi, seteara el atributo docente en null, ya sea que tenga un docente asignado o no.