### PR TITLE
feat: Agregue enums en Benefit. #166

### DIFF
--- a/src/main/java/trinity/play2learn/backend/benefits/dtos/BenefitRequestDto.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/dtos/BenefitRequestDto.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import trinity.play2learn.backend.benefits.models.BenefitCategory;
+import trinity.play2learn.backend.benefits.models.BenefitColor;
+import trinity.play2learn.backend.benefits.models.BenefitIcon;
 import trinity.play2learn.backend.configs.messages.ValidationMessages;
 
 @Data
@@ -33,4 +36,13 @@ public class BenefitRequestDto {
 
     @NotNull(message = ValidationMessages.NOT_NULL_SUBJECT)
     private Long subjectId;
+
+    @NotNull(message = ValidationMessages.NOT_NULL_ICON)
+    private BenefitIcon icon;
+    
+    @NotNull(message = ValidationMessages.NOT_NULL_CATEGORY)
+    private BenefitCategory category;
+
+    @NotNull(message = ValidationMessages.NOT_NULL_COLOR)
+    private BenefitColor color;
 }

--- a/src/main/java/trinity/play2learn/backend/benefits/dtos/BenefitResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/dtos/BenefitResponseDto.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import trinity.play2learn.backend.admin.subject.dtos.SubjectResponseDto;
+import trinity.play2learn.backend.benefits.models.BenefitCategory;
+import trinity.play2learn.backend.benefits.models.BenefitColor;
+import trinity.play2learn.backend.benefits.models.BenefitIcon;
 
 @Data
 @Builder
@@ -17,5 +20,7 @@ public class BenefitResponseDto {
     private Integer totalRedeemableAmount;
     private Integer redeemableAmountPerStudent;
     private SubjectResponseDto subjectDto;
-    
+    private BenefitIcon icon;
+    private BenefitCategory category;
+    private BenefitColor color;
 }

--- a/src/main/java/trinity/play2learn/backend/benefits/mappers/BenefitMapper.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/mappers/BenefitMapper.java
@@ -18,6 +18,9 @@ public class BenefitMapper {
             .totalRedeemableAmount(benefitDto.getTotalRedeemableAmount())
             .redeemableAmountPerStudent(benefitDto.getRedeemableAmountPerStudent())
             .subject(subject)
+            .icon(benefitDto.getIcon())
+            .category(benefitDto.getCategory())
+            .color(benefitDto.getColor())
             .build();
     }
 
@@ -30,6 +33,9 @@ public class BenefitMapper {
             .totalRedeemableAmount(benefit.getTotalRedeemableAmount())
             .redeemableAmountPerStudent(benefit.getRedeemableAmountPerStudent())
             .subjectDto(SubjectMapper.toSubjectDto(benefit.getSubject()))
+            .icon(benefit.getIcon())
+            .category(benefit.getCategory())
+            .color(benefit.getColor())
             .build();
     }
 

--- a/src/main/java/trinity/play2learn/backend/benefits/models/Benefit.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/models/Benefit.java
@@ -3,6 +3,8 @@ package trinity.play2learn.backend.benefits.models;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -53,6 +55,18 @@ public class Benefit {
     @ManyToOne
     @NotNull
     private Subject subject;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private BenefitIcon icon;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private BenefitCategory category;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private BenefitColor color;
 
     private LocalDateTime deletedAt;
 

--- a/src/main/java/trinity/play2learn/backend/benefits/models/BenefitCategory.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/models/BenefitCategory.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.benefits.models;
+
+public enum BenefitCategory {
+    EVALUACION,
+    ASISTENCIA,
+    TRABAJOS,
+    EXTRAS
+}

--- a/src/main/java/trinity/play2learn/backend/benefits/models/BenefitColor.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/models/BenefitColor.java
@@ -1,0 +1,12 @@
+package trinity.play2learn.backend.benefits.models;
+
+public enum BenefitColor {
+    BLUE,
+    ORANGE,
+    LIGHTGREEN,
+    EMERALD,
+    PURPLE,
+    AMBER,
+    RED,
+    GRAY
+}

--- a/src/main/java/trinity/play2learn/backend/benefits/models/BenefitIcon.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/models/BenefitIcon.java
@@ -1,0 +1,12 @@
+package trinity.play2learn.backend.benefits.models;
+
+public enum BenefitIcon {
+    EXAM,
+    FILE,
+    SKIP,
+    CALENDAR,
+    CHAT,
+    CLOCK,
+    BOOK,
+    RETRY
+}

--- a/src/main/java/trinity/play2learn/backend/configs/messages/ValidationMessages.java
+++ b/src/main/java/trinity/play2learn/backend/configs/messages/ValidationMessages.java
@@ -99,5 +99,9 @@ public class ValidationMessages {
     //------------------------------------- BENEFIT ------------------------------------------------------
     public static final String NOT_NULL_COST = "El costo no puede estar vacio.";
     public static final String MIN_COST = "El costo debe ser mayor a 0.";
+    public static final String NOT_NULL_ICON = "El icono no puede estar vacio.";
+    public static final String NOT_NULL_CATEGORY = "La categoria no puede estar vaciq.";
+    public static final String NOT_NULL_COLOR = "El color no puede estar vacio.";
+    
 }
 


### PR DESCRIPTION
Agregue los siguientes enums en Benefit:

Iconos:

- exam
- file
- skip
- calendar
- chat
- clock
- book
- retry

Categorias:

- Evaluacion
- Asistencia
- Trabajos
- extras

colores:

- blue
- orange
- lightgreen
- emerald
- purple
- amber
- red
- gray

Ahora el JSON de para generar un beneficio espera estos tres atributos:
```json
"icon":"SKIP",
 "category":"EXTRAS",
 "color":"RED"
  ```
  
  Los mismos no pueden ser nulos