### PR TITLE
feat: Endpoint para listar las actividades aprobadas del estudiante. #196

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentController.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
-import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetNotApprovedByStudentService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListApproveByStudentService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListNotApprovedByStudentService;
 import trinity.play2learn.backend.configs.annotations.SessionRequired;
 import trinity.play2learn.backend.configs.annotations.SessionUser;
 import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
@@ -21,9 +23,10 @@ import trinity.play2learn.backend.user.models.User;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/activity/student")
-public class ActivityGetByStudentController {
+public class ActivityListByStudentController {
     
-    private final IActivityGetNotApprovedByStudentService activityGetNotApprovedByStudentService;
+    private final IActivityListNotApprovedByStudentService activityGetNotApprovedByStudentService;
+    private final IActivityListApproveByStudentService activityGetApprovedByStudentService;
 
     @GetMapping("/not-approved")
     @SessionRequired(roles = {Role.ROLE_STUDENT})
@@ -31,4 +34,13 @@ public class ActivityGetByStudentController {
 
         return ResponseFactory.ok(activityGetNotApprovedByStudentService.cu62ListNotApprovedActivitiesByStudent(user), SuccessfulMessages.okSuccessfully());
     }
+
+    @GetMapping("/approved")
+    @SessionRequired(roles = {Role.ROLE_STUDENT})
+    public ResponseEntity<BaseResponse<List<ActivityStudentApprovedResponseDto>>> listApprovedActivities(@SessionUser User user) {
+
+        return ResponseFactory.ok(activityGetApprovedByStudentService.cu63ListApprovedActivitiesByStudent(user), SuccessfulMessages.okSuccessfully());
+    }
+
+
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentApprovedResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentApprovedResponseDto.java
@@ -1,0 +1,25 @@
+package trinity.play2learn.backend.activity.activity.dtos.activityStudent;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import trinity.play2learn.backend.activity.activity.models.activity.Dificulty;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ActivityStudentApprovedResponseDto {
+    
+    private Long id;
+    private String name; 
+    private String description;
+    private Dificulty difficulty;
+    private String subjectName;
+    private int attempts;
+    private Integer remainingAttempts; //Intentos restantes del estudiante en la actividad
+    private LocalDateTime completedAt;
+    private Double reward;
+}
+

--- a/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
@@ -1,12 +1,15 @@
 package trinity.play2learn.backend.activity.activity.mappers;
 
+import java.time.LocalDateTime;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.models.activity.ActivityStatus;
 
 public class ActivityMapper {
     
-    public static ActivityStudentNotApprovedResponseDto toStudentDto(
+    public static ActivityStudentNotApprovedResponseDto toNotApprovedDto(
             Activity activity , Integer remainingAttempts, Boolean pending,
             ActivityStatus status, Double minReward, Double maxReward
         ) {
@@ -28,4 +31,19 @@ public class ActivityMapper {
             .pending(pending)
             .build();
     }
+
+    public static ActivityStudentApprovedResponseDto toApprovedDto( Activity activity , Integer remainingAttempts, Double reward, LocalDateTime completedAt ) {
+
+            return ActivityStudentApprovedResponseDto.builder()
+                .id(activity.getId())
+                .name(activity.getName())
+                .description(activity.getDescription())
+                .difficulty(activity.getDificulty())
+                .subjectName(activity.getSubject().getName())
+                .attempts(activity.getAttempts())
+                .remainingAttempts(remainingAttempts)
+                .completedAt(completedAt)
+                .reward(reward)
+                .build();
+        }
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListApprovedByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListApprovedByStudentService.java
@@ -1,0 +1,37 @@
+package trinity.play2learn.backend.activity.activity.services;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListApproveByStudentService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.user.models.User;
+
+@Service
+@AllArgsConstructor
+public class ActivityListApprovedByStudentService implements IActivityListApproveByStudentService {
+    
+    private final IStudentGetByEmailService studentGetByEmailService;
+    private final IActivityGetByStudentService activityGetByStudentService;
+    private final IActivityCreateApprovedDtosService activityCreateApprovedDtosService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ActivityStudentApprovedResponseDto> cu63ListApprovedActivitiesByStudent(User user) {
+        
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        //Obtengo todas las actividades del estudiante segun las materias a las que esta asignado
+        List<Activity> activities = activityGetByStudentService.getByStudent(student);
+
+        return activityCreateApprovedDtosService.createApprovedDtos(activities, student);
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListNotApprovedByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListNotApprovedByStudentService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
-import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetNotApprovedByStudentService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListNotApprovedByStudentService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateNotApprovedDtosService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
 import trinity.play2learn.backend.admin.student.models.Student;
@@ -16,7 +16,7 @@ import trinity.play2learn.backend.user.models.User;
 
 @Service
 @AllArgsConstructor
-public class ActivityGetNotApprovedByStudentService implements IActivityGetNotApprovedByStudentService {
+public class ActivityListNotApprovedByStudentService implements IActivityListNotApprovedByStudentService {
     
     private final IStudentGetByEmailService studentGetByEmailService;
     private final IActivityGetByStudentService activityGetByStudentService;

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateApprovedDtosService.java
@@ -1,0 +1,52 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.mappers.ActivityMapper;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetLastCompletedService;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Service
+@AllArgsConstructor
+public class ActivityCreateApprovedDtosService implements IActivityCreateApprovedDtosService {
+    
+    private final IActivityGetLastCompletedService activityGetLastCompletedService;
+
+    @Override
+    public List<ActivityStudentApprovedResponseDto> createApprovedDtos(List<Activity> activities, Student student) {
+        
+        List<ActivityStudentApprovedResponseDto> activitiesDto = new ArrayList<>();
+
+        for (Activity activity : activities) {
+
+            ActivityCompleted lastCompleted = activityGetLastCompletedService.getLastCompleted(activity, student);
+            
+            if (lastCompleted == null) {
+
+                continue;
+            }
+
+            if (lastCompleted.getState() != ActivityCompletedState.APPROVED) {
+                
+                continue; //Salta a la siguiente iteracion
+            }
+            
+            activitiesDto.add(ActivityMapper.toApprovedDto(activity, lastCompleted.getRemainingAttempts(), lastCompleted.getReward(), lastCompleted.getCompletedAt()));
+
+        }
+
+        return activitiesDto;
+
+    }
+    
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
@@ -51,7 +51,7 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
                 pending = true;
             }
             
-            activitiesDto.add(ActivityMapper.toStudentDto(activity, remainingAttempts, pending, activityStatus, minReward, maxReward));
+            activitiesDto.add(ActivityMapper.toNotApprovedDto(activity, remainingAttempts, pending, activityStatus, minReward, maxReward));
 
         }
 

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityGetLastCompletedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityGetLastCompletedService.java
@@ -1,0 +1,24 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetLastCompletedService;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Service
+@AllArgsConstructor
+public class ActivityGetLastCompletedService implements IActivityGetLastCompletedService {
+    
+    private final IActivityCompletedRepository activityCompletedRepository;
+
+    @Override
+    public ActivityCompleted getLastCompleted(Activity activity, Student student) {
+
+        return activityCompletedRepository.findTopByActivityAndStudentOrderByCompletedAtDesc(activity, student).orElse(null);
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCreateApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCreateApprovedDtosService.java
@@ -1,0 +1,12 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityCreateApprovedDtosService {
+    
+    List<ActivityStudentApprovedResponseDto> createApprovedDtos(List<Activity> activities, Student student);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityGetLastCompletedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityGetLastCompletedService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityGetLastCompletedService {
+    
+    ActivityCompleted getLastCompleted(Activity activity, Student student);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListApproveByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListApproveByStudentService.java
@@ -1,0 +1,11 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IActivityListApproveByStudentService {
+    
+    List<ActivityStudentApprovedResponseDto> cu63ListApprovedActivitiesByStudent(User user);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListNotApprovedByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListNotApprovedByStudentService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.user.models.User;
 
-public interface IActivityGetNotApprovedByStudentService {
+public interface IActivityListNotApprovedByStudentService {
     
     List<ActivityStudentNotApprovedResponseDto> cu62ListNotApprovedActivitiesByStudent(User user);
 }

--- a/src/main/java/trinity/play2learn/backend/admin/course/controllers/CourseListPaginatedController.java
+++ b/src/main/java/trinity/play2learn/backend/admin/course/controllers/CourseListPaginatedController.java
@@ -25,7 +25,6 @@ public class CourseListPaginatedController {
 
     private final ICourseListPaginatedService courseListPaginatedService;
 
-
     @GetMapping ("/paginated")
     @SessionRequired(roles = {Role.ROLE_ADMIN, Role.ROLE_TEACHER, Role.ROLE_STUDENT})
     public ResponseEntity<BaseResponse<PaginatedData<CourseResponseDto>>> listPaginated(


### PR DESCRIPTION
Cree un endpoint que lista las actividades en estado APPROVE de un estudiante. El mismo puede ser accedido unicamente por usuarios de rol `STUDENT` y mediante la URI `GET` `/activity/student/approved`. Devuelve un Json como este:
```json
{
    "data": [
        {
            "id": 3,
            "name": "Ahorcado",
            "description": "Adivina la palabra",
            "difficulty": "MEDIO",
            "subjectName": "Lengua",
            "attempts": 5,
            "remainingAttempts": 5,
            "completedAt": "2025-09-03T11:29:35.502478",
            "reward": 0.0
        },
        {
            "id": 5,
            "name": "Ahorcado",
            "description": "Adivina la palabra",
            "difficulty": "MEDIO",
            "subjectName": "Lengua",
            "attempts": 5,
            "remainingAttempts": 5,
            "completedAt": "2025-09-04T11:23:30.269777",
            "reward": 0.0
        },
        {
            "id": 9,
            "name": "sin nombre",
            "description": "Adivina la palabra",
            "difficulty": "MEDIO",
            "subjectName": "Matematica",
            "attempts": 5,
            "remainingAttempts": 3,
            "completedAt": "2025-09-04T11:27:05.649747",
            "reward": 0.0
        }
    ],
    "message": "OK",
    "errors": null,
    "timestamp": "
```