### PR TITLE
197 Validaciones para realizar actividad

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityValidatePublishedStatusService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityValidatePublishedStatusService.java
@@ -1,0 +1,27 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityValidatePublishedStatusService;
+import trinity.play2learn.backend.configs.exceptions.ConflictException;
+
+@Service
+@AllArgsConstructor
+public class ActivityValidatePublishedStatusService implements IActivityValidatePublishedStatusService {
+
+    //Valida que la actividad este publicada (Fecha actual dentro de la fecha de inicio y fin de la actividad)
+    @Override
+    public void validatePublishedStatus(Activity activity) {
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(activity.getStartDate()) || now.isAfter(activity.getEndDate())) {
+
+            throw new ConflictException("No es posible realizar la actividad ya que no está publicada.");
+        }
+    }
+    
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedStrategyService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedStrategyService.java
@@ -6,5 +6,5 @@ import trinity.play2learn.backend.admin.student.models.Student;
 
 public interface IActivityCompletedStrategyService {
     
-    ActivityCompletedResponseDto execute(Activity activity, Student student);
+    ActivityCompletedResponseDto execute(Activity activity, Student student, Integer remainingAttempts);
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityValidatePublishedStatusService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityValidatePublishedStatusService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+
+public interface IActivityValidatePublishedStatusService {
+    
+    void validatePublishedStatus(Activity activity);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityApprovedStrategyService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityApprovedStrategyService.java
@@ -10,7 +10,6 @@ import trinity.play2learn.backend.activity.activity.models.activityCompleted.Act
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
 import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedStrategyService;
-import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetRemainingAttemptsService;
 import trinity.play2learn.backend.admin.student.models.Student;
 
 @Service("APPROVED")
@@ -18,12 +17,9 @@ import trinity.play2learn.backend.admin.student.models.Student;
 public class ActivityApprovedStrategyService implements IActivityCompletedStrategyService {
     
     private final IActivityCompletedRepository activityCompletedRepository;
-    private final IActivityGetRemainingAttemptsService getRemainingAttemptsService;
 
     @Override
-    public ActivityCompletedResponseDto execute(Activity activity, Student student) {
-
-        Integer remainingAttempts = getRemainingAttemptsService.getStudentRemainingAttempts(activity, student);
+    public ActivityCompletedResponseDto execute(Activity activity, Student student, Integer remainingAttempts) {
 
         //Aca se llamaria al servicio de calcular la recompensa cuando este implementado segun como entregue recompensa la actividad (Strategy)
         Double reward = 0.0;

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityDisapprovedStrategyService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityDisapprovedStrategyService.java
@@ -11,7 +11,6 @@ import trinity.play2learn.backend.activity.activity.models.activityCompleted.Act
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
 import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedStrategyService;
-import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetRemainingAttemptsService;
 import trinity.play2learn.backend.admin.student.models.Student;
 
 @Service("DISAPPROVED")
@@ -19,14 +18,13 @@ import trinity.play2learn.backend.admin.student.models.Student;
 public class ActivityDisapprovedStrategyService implements IActivityCompletedStrategyService{
     
     private final IActivityCompletedRepository activityCompletedRepository;
-    private final IActivityGetRemainingAttemptsService getRemainingAttemptsService;
 
     @Override
     @Transactional
-    public ActivityCompletedResponseDto execute(Activity activity, Student student) {
+    public ActivityCompletedResponseDto execute(Activity activity, Student student, Integer remainingAttempts) {
         
-        //Obtiene los intentos restantes del estudiante en la actividad y le resta 1, ya que la desaprobo
-        Integer remainingAttempts = getRemainingAttemptsService.getStudentRemainingAttempts(activity, student) - 1;
+        //Le resta 1 a los intentos restantes del estudiante, ya que la desaprobo
+        remainingAttempts-=1;
         
         ActivityCompleted activityCompleted = ActivityCompletedMapper.toModel(activity, student, null, remainingAttempts, ActivityCompletedState.DISAPPROVED);
         

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityPendingStrategyService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityPendingStrategyService.java
@@ -11,7 +11,6 @@ import trinity.play2learn.backend.activity.activity.models.activityCompleted.Act
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
 import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedStrategyService;
-import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetRemainingAttemptsService;
 import trinity.play2learn.backend.admin.student.models.Student;
 
 @Service("PENDING")
@@ -19,14 +18,11 @@ import trinity.play2learn.backend.admin.student.models.Student;
 public class ActivityPendingStrategyService implements IActivityCompletedStrategyService{
     
     private final IActivityCompletedRepository activityCompletedRepository;
-    private final IActivityGetRemainingAttemptsService getRemainingAttemptsService;
 
     @Override
     @Transactional
-    public ActivityCompletedResponseDto execute(Activity activity, Student student) {
+    public ActivityCompletedResponseDto execute(Activity activity, Student student , Integer remainingAttempts) {
         
-        Integer remainingAttempts = getRemainingAttemptsService.getStudentRemainingAttempts(activity, student);
-
         ActivityCompleted activityCompleted = ActivityCompletedMapper.toModel(activity, student, null, remainingAttempts, ActivityCompletedState.PENDING);
         
         return ActivityCompletedMapper.toDto(activityCompletedRepository.save(activityCompleted));


### PR DESCRIPTION
Agregue 3 validaciones en el endpoint para realizar actividad, accedido mediante la URI `POST` `/activity/completed`:
- Actividad publicada: Fecha actual dentro del rango de fecha de inicio y fin de la actividad
- Actividad no aprobada: La actividad no debe haber sido aprobada por el estudiante.
- Intentos restantes: Los intentos restantes de la actividad no pueden ser 0.