### PR TITLE
feat Get Last movements

### DIFF
--- a/src/main/java/trinity/play2learn/backend/economy/transaction/repositories/ITransactionRepository.java
+++ b/src/main/java/trinity/play2learn/backend/economy/transaction/repositories/ITransactionRepository.java
@@ -1,9 +1,14 @@
 package trinity.play2learn.backend.economy.transaction.repositories;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
 import trinity.play2learn.backend.economy.transaction.models.Transaction;
+import trinity.play2learn.backend.economy.wallet.models.Wallet;
 
 public interface ITransactionRepository extends CrudRepository<Transaction, Long> {
+
+    public List<Transaction> findTop10ByWalletOrderByCreatedAtDesc(Wallet wallet);
     
 }

--- a/src/main/java/trinity/play2learn/backend/economy/transaction/services/commons/TransactionGetLastTransactionsService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/transaction/services/commons/TransactionGetLastTransactionsService.java
@@ -1,0 +1,24 @@
+package trinity.play2learn.backend.economy.transaction.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.economy.transaction.models.Transaction;
+import trinity.play2learn.backend.economy.transaction.repositories.ITransactionRepository;
+import trinity.play2learn.backend.economy.transaction.services.interfaces.ITransactionGetLastTransaccionsService;
+import trinity.play2learn.backend.economy.wallet.models.Wallet;
+
+@Service
+@AllArgsConstructor
+public class TransactionGetLastTransactionsService implements ITransactionGetLastTransaccionsService {
+    
+    private final ITransactionRepository transactionRepository;
+    
+    @Override
+    public List<Transaction> execute(Wallet wallet) {
+        return transactionRepository.findTop10ByWalletOrderByCreatedAtDesc(wallet);
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/economy/transaction/services/interfaces/ITransactionGetLastTransaccionsService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/transaction/services/interfaces/ITransactionGetLastTransaccionsService.java
@@ -1,0 +1,11 @@
+package trinity.play2learn.backend.economy.transaction.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.economy.transaction.models.Transaction;
+import trinity.play2learn.backend.economy.wallet.models.Wallet;
+
+public interface ITransactionGetLastTransaccionsService {
+    
+    public List<Transaction> execute (Wallet wallet);
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/controllers/WalletGetLastMovementsController.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/controllers/WalletGetLastMovementsController.java
@@ -1,0 +1,40 @@
+package trinity.play2learn.backend.economy.wallet.controllers;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.configs.annotations.SessionRequired;
+import trinity.play2learn.backend.configs.annotations.SessionUser;
+import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.economy.wallet.dtos.response.MovementResponseDto;
+import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetLastMovementsService;
+import trinity.play2learn.backend.user.models.Role;
+import trinity.play2learn.backend.user.models.User;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/wallet")
+public class WalletGetLastMovementsController {
+
+    private final IWalletGetLastMovementsService walletGetLastMovementsService;
+
+    @GetMapping("/last-movements")
+    @SessionRequired(roles = {Role.ROLE_STUDENT})
+    public ResponseEntity<BaseResponse<List<MovementResponseDto>>> getLastMovements(
+        @SessionUser User user){ 
+        
+        return ResponseFactory.ok(
+            walletGetLastMovementsService.cu65GetLastMovements(user), 
+            SuccessfulMessages.okSuccessfully()
+        );
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/dtos/response/MovementResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/dtos/response/MovementResponseDto.java
@@ -1,0 +1,22 @@
+package trinity.play2learn.backend.economy.wallet.dtos.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class MovementResponseDto {
+
+    public Double amount;
+
+    public LocalDateTime createdAt;
+
+    public String description;
+
+    public String type;
+    
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/mappers/MovementMapper.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/mappers/MovementMapper.java
@@ -1,0 +1,24 @@
+package trinity.play2learn.backend.economy.wallet.mappers;
+
+import java.util.List;
+
+import trinity.play2learn.backend.economy.transaction.models.Transaction;
+import trinity.play2learn.backend.economy.transaction.models.TransactionActor;
+import trinity.play2learn.backend.economy.wallet.dtos.response.MovementResponseDto;
+
+public class MovementMapper {
+
+    public static final MovementResponseDto toDto (Transaction transaction) {
+        return MovementResponseDto.builder()
+            .amount(Math.round(transaction.getAmount() * 1000.0) / 1000.0)
+            .createdAt(transaction.getCreatedAt())
+            .description(transaction.getDescription())
+            .type((transaction.getOrigin() == TransactionActor.ESTUDIANTE) ? "EGRESO" : "INGRESO")
+            .build();
+    }
+
+    public static final List<MovementResponseDto> toDtoList (List<Transaction> transactions) {
+        return transactions.stream().map(MovementMapper::toDto).toList();
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/services/WalletGetLastMovementsService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/services/WalletGetLastMovementsService.java
@@ -1,0 +1,35 @@
+package trinity.play2learn.backend.economy.wallet.services;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.economy.transaction.models.Transaction;
+import trinity.play2learn.backend.economy.transaction.services.interfaces.ITransactionGetLastTransaccionsService;
+import trinity.play2learn.backend.economy.wallet.dtos.response.MovementResponseDto;
+import trinity.play2learn.backend.economy.wallet.mappers.MovementMapper;
+import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetLastMovementsService;
+import trinity.play2learn.backend.user.models.User;
+
+@Service
+@AllArgsConstructor
+public class WalletGetLastMovementsService implements IWalletGetLastMovementsService {
+    
+    private final IStudentGetByEmailService studentGetByEmailService;
+
+    private final ITransactionGetLastTransaccionsService transactionGetLastTransaccionsService;
+
+    @Override
+    public List<MovementResponseDto> cu65GetLastMovements(User user) {
+
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        List<Transaction> transactions = transactionGetLastTransaccionsService.execute(student.getWallet());
+
+        return MovementMapper.toDtoList(transactions);
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/services/interfaces/IWalletGetLastMovementsService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/services/interfaces/IWalletGetLastMovementsService.java
@@ -1,0 +1,12 @@
+package trinity.play2learn.backend.economy.wallet.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.economy.wallet.dtos.response.MovementResponseDto;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IWalletGetLastMovementsService {
+    
+    public List<MovementResponseDto> cu65GetLastMovements (User user);
+    
+}


### PR DESCRIPTION
Agregue un endpoitn en la url /wallet/last-movements y trae un resumen de los ultimos 10 movimientos de una cuenta.
El mismo obtiene el usuario mediante el access token, y busca el estudiante y la wallet.
Retorna esto:

```json
{
    "data": [
        {
            "amount": 0.004,
            "createdAt": "2025-09-04T12:52:02.786358",
            "description": "Recompensa por actividad completada",
            "type": "INGRESO"
        },
        {
            "amount": 1428.571,
            "createdAt": "2025-09-04T11:30:59.33565",
            "description": "Recompensa por actividad completada",
            "type": "INGRESO"
        }
    ],
    "message": "OK",
    "errors": null,
    "timestamp": "2025-09-05T23:38:03.151026700Z"
}
```

Devuelve los utlimos 10 movimientos con su monto, fecha de creacion, descripcion y tipo.

El tipo es un valor calculable con dos resultados:
- INGRESO: Si el Transaccion Actor de tipo Student es el destinatario.
- EGRESO: Si el Transaccion Actor de tipo Student es el emisor de la transaccion.
