### PR TITLE
200 crear endpoint para listar con paginacion actividades no aprobadas

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
@@ -1,0 +1,47 @@
+package trinity.play2learn.backend.activity.activity.controllers;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityNotApprovedListPaginatedService;
+import trinity.play2learn.backend.configs.annotations.SessionRequired;
+import trinity.play2learn.backend.configs.annotations.SessionUser;
+import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+import trinity.play2learn.backend.user.models.User;
+
+@RestController
+@RequestMapping("/activity/student/paginated")
+@AllArgsConstructor
+public class ActivityListPaginatedByStudentController {
+
+    private final IActivityNotApprovedListPaginatedService activityNotApprovedListPaginatedService;
+
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    @GetMapping("/not-approved")
+    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentNotApprovedResponseDto>>> getActivitiesPaginatedByStudent(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
+            @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
+            @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
+            @RequestParam(required = false) String search,
+            @RequestParam(name = "filters", required = false) List<String> filters,
+            @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
+            @SessionUser User user) {
+
+        return ResponseFactory.paginated(
+                activityNotApprovedListPaginatedService.cu66listNotApprovedActivitiesPaginated(page, pageSize, orderBy,
+                        orderType, search, filters, filtersValues, user),
+                SuccessfulMessages.okSuccessfully());
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityPaginatedRepository.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityPaginatedRepository.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.activity.activity.repositories;
+
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.CrudRepository;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+
+public interface IActivityPaginatedRepository extends CrudRepository<Activity, Long>, JpaSpecificationExecutor<Activity> {
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListNotApprovedByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityListNotApprovedByStudentService.java
@@ -9,6 +9,7 @@ import trinity.play2learn.backend.activity.activity.dtos.activityStudent.Activit
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListNotApprovedByStudentService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateNotApprovedDtosService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterNotApprovedService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
@@ -21,6 +22,7 @@ public class ActivityListNotApprovedByStudentService implements IActivityListNot
     private final IStudentGetByEmailService studentGetByEmailService;
     private final IActivityGetByStudentService activityGetByStudentService;
     private final IActivityCreateNotApprovedDtosService activityCreateNotApprovedDtosService;
+    private final IActivityFilterNotApprovedService activityFilterNotApprovedService;
 
     //Devuelve las activdades que aun no han sido aprobadas por el estudiante
     @Override
@@ -32,8 +34,11 @@ public class ActivityListNotApprovedByStudentService implements IActivityListNot
         //Obtengo todas las actividades del estudiante segun las materias a las que esta asignado
         List<Activity> activities = activityGetByStudentService.getByStudent(student);
 
-        //Filtra las actividades que aun no han sido aprobadas y crea los dtos
-        return activityCreateNotApprovedDtosService.createNotApprovedDtos(activities, student);
+        //Filtro las actividades que aun no han sido aprobadas por el estudiante
+        List<Activity> notApprovedActivities = activityFilterNotApprovedService.filterByNotApproved(activities, student);
+
+        //Crea los dtos
+        return activityCreateNotApprovedDtosService.createNotApprovedDtos(notApprovedActivities, student);
     }
         
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityNotApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityNotApprovedListPaginatedService.java
@@ -1,0 +1,101 @@
+package trinity.play2learn.backend.activity.activity.services;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityPaginatedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateNotApprovedDtosService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterNotApprovedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityNotApprovedListPaginatedService;
+import trinity.play2learn.backend.activity.activity.specs.ActivitySpecs;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+import trinity.play2learn.backend.utils.PaginationHelper;
+import trinity.play2learn.backend.utils.PaginatorUtils;
+
+@Service
+@AllArgsConstructor
+public class ActivityNotApprovedListPaginatedService implements IActivityNotApprovedListPaginatedService {
+
+    private final IActivityPaginatedRepository activityRepository;
+    private final IActivityCreateNotApprovedDtosService activityCreateNotApprovedDtosService;
+    private final IStudentGetByEmailService studentGetByEmailService;
+    private final IActivityGetByStudentService activityGetByStudentService;
+    private final IActivityFilterNotApprovedService activityFilterNotApprovedService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedData<ActivityStudentNotApprovedResponseDto> cu66listNotApprovedActivitiesPaginated(
+            int page,
+            int size,
+            String orderBy,
+            String orderType,
+            String search,
+            List<String> filters,
+            List<String> filterValues,
+            User user) {
+
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        // Obtengo todas las actividades del estudiante segun las materias a las que
+        // esta asignado
+        List<Activity> activities = activityGetByStudentService.getByStudent(student);
+
+        // Filtro por las no aprobadas
+        List<Activity> notApprovedActivities = activityFilterNotApprovedService.filterByNotApproved(activities,
+                student);
+
+        // Creo una lista con los ids de las actividades no aprobadas del estudiante
+        List<Long> activityIds = notApprovedActivities.stream()
+                .map(Activity::getId)
+                .toList();
+
+        Pageable pageable = PaginatorUtils.buildPageable(page, size, orderBy, orderType);
+        Specification<Activity> spec = Specification.where(ActivitySpecs.notDeleted());
+
+        if (search != null && !search.isBlank()) {
+            spec = spec.and(ActivitySpecs.nameContains(search));
+        }
+
+        if (filters != null && filterValues != null && filters.size() == filterValues.size()) {
+            for (int i = 0; i < filters.size(); i++) {
+                String field = filters.get(i);
+                String value = filterValues.get(i);
+
+                //Si el filtro es de materia, lo agrego a la spec, sino filtra normalmente
+                if ("subjectId".equals(field)) {
+                    spec = spec.and(ActivitySpecs.hasSubjectId(Long.valueOf(value)));
+                } else {
+
+                    spec = spec.and(ActivitySpecs.genericFilter(field, value));
+                }
+            }
+        }
+
+        // Restricción por estudiante: solo actividades dentro de la lista obtenida
+        if (!activityIds.isEmpty()) {
+            spec = spec.and((root, query, cb) -> root.get("id").in(activityIds));
+        } else {
+            // Si el estudiante no tiene actividades, devolvemos un Page vacío
+            return PaginationHelper.fromPage(Page.empty(pageable), List.of());
+        }
+
+        Page<Activity> pageResult = activityRepository.findAll(spec, pageable);
+
+        List<ActivityStudentNotApprovedResponseDto> dtos = activityCreateNotApprovedDtosService
+                .createNotApprovedDtos(pageResult.getContent(), student);
+
+        return PaginationHelper.fromPage(pageResult, dtos);
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
@@ -31,7 +31,6 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
 
     private final Map<String, IActivityCalculateRewardStrategyService> activityCalculateRewardStrategyServiceMap;
 
-
     @Override
     public List<ActivityStudentNotApprovedResponseDto> createNotApprovedDtos(List<Activity> activities, Student student) {
 
@@ -39,13 +38,6 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
 
         for (Activity activity : activities) {
 
-            ActivityCompletedState activityCompletedState = activityGetCompletedStateService.getActivityCompletedState(activity, student);
-            
-            if (activityCompletedState == ActivityCompletedState.APPROVED) {
-                
-                continue; //Salta a la siguiente iteracion
-            }
-            
             Integer remainingAttempts = activityGetRemainingAttemptsService.getStudentRemainingAttempts(activity, student);
 
             ActivityStatus activityStatus = activityGetStatusService.getStatus(activity);
@@ -58,7 +50,7 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
             
             Boolean pending = false;
 
-            if (activityCompletedState == ActivityCompletedState.PENDING) {
+            if (activityGetCompletedStateService.getActivityCompletedState(activity, student) == ActivityCompletedState.PENDING) {
                 pending = true;
             }
             

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterNotApprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterNotApprovedService.java
@@ -1,0 +1,29 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterNotApprovedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetCompletedStateService;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Service
+@AllArgsConstructor
+public class ActivityFilterNotApprovedService implements IActivityFilterNotApprovedService {
+    
+    private final IActivityGetCompletedStateService activityGetCompletedStateService;
+
+    @Override
+    public List<Activity> filterByNotApproved(List<Activity> activities, Student student) {
+
+        return activities
+            .stream()
+            .filter(activity -> activityGetCompletedStateService.getActivityCompletedState(activity, student) != ActivityCompletedState.APPROVED)
+            .toList();
+    }
+    
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterNotApprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterNotApprovedService.java
@@ -1,0 +1,11 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityFilterNotApprovedService {
+    
+    List<Activity> filterByNotApproved(List<Activity> activities, Student student);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityNotApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityNotApprovedListPaginatedService.java
@@ -1,0 +1,21 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IActivityNotApprovedListPaginatedService {
+    
+    PaginatedData<ActivityStudentNotApprovedResponseDto> cu66listNotApprovedActivitiesPaginated(
+            int page,
+            int size, 
+            String orderBy, 
+            String orderType, 
+            String search, 
+            List<String> filters,
+            List<String> filterValues,
+            User user
+        );
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/specs/ActivitySpecs.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/specs/ActivitySpecs.java
@@ -1,0 +1,41 @@
+package trinity.play2learn.backend.activity.activity.specs;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+
+public class ActivitySpecs {
+
+    // Filtro base: trae solo los que NO fueron eliminados lógicamente
+    public static Specification<Activity> notDeleted() {
+        return (root, query, cb) -> cb.isNull(root.get("deletedAt"));
+    }
+
+    // Filtro por búsqueda textual (ej: nombre LIKE %search%)
+    public static Specification<Activity> nameContains(String search) {
+        return (root, query, cb) -> cb.like(cb.lower(root.get("name")), "%" + search.toLowerCase() + "%");
+    }
+
+    // Filtro dinámico: cualquier campo = valor exacto
+    public static Specification<Activity> genericFilter(String field, String value) {
+        return (root, query, cb) -> {
+            try {
+                // Este get es dinámico, pero puede fallar si el campo no existe
+                return cb.equal(root.get(field), value);
+            } catch (IllegalArgumentException e) {
+
+                return cb.conjunction(); // no aplica ningún filtro
+            }
+        };
+    }
+
+    public static Specification<Activity> hasSubjectId(Long subjectId) {
+        return (root, query, cb) -> {
+            if (subjectId == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("subject").get("id"), subjectId);
+        };
+    }
+
+}


### PR DESCRIPTION
Cree un endpoint para listar con paginacion las actividades no aprobadas del estudiante. El mismo puede ser accedido solo por el estudiante mediante la URI `GET` `/activity/student/paginated/not-approved`.
Espera los siguientes parametros: 

- page: Numero de pagina, por defecto 1.
- page_size: Tamaño de pagina, por defecto 10
- order_by: Atributo por el cual ordenar, por defecto id
- order_type: desc o asc, por defecto asc
- search: Busca sobre el name
- filters: Espera el nombre de un atibuto
- filtersValues:Espera el valor exacto del atributo por el cual filtrar

Los atributos por los cuales se puede filtrar son:
- id
- name
- description
- difficulty
- maxTime
- attempts
- subjectId

