### PR TITLE
feat: Crear endpoint para listar las actividades aprobadas con paginacion. #216

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityApprovedListPaginatedService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityNotApprovedListPaginatedService;
 import trinity.play2learn.backend.configs.annotations.SessionRequired;
 import trinity.play2learn.backend.configs.annotations.SessionUser;
@@ -26,10 +28,11 @@ import trinity.play2learn.backend.user.models.User;
 public class ActivityListPaginatedByStudentController {
 
     private final IActivityNotApprovedListPaginatedService activityNotApprovedListPaginatedService;
-
+    private final IActivityApprovedListPaginatedService activityApprovedListPaginatedService;
+    
     @SessionRequired(roles = { Role.ROLE_STUDENT })
     @GetMapping("/not-approved")
-    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentNotApprovedResponseDto>>> getActivitiesPaginatedByStudent(
+    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentNotApprovedResponseDto>>> getNotApprovedActivitiesPaginatedByStudent(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
             @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
@@ -41,6 +44,24 @@ public class ActivityListPaginatedByStudentController {
 
         return ResponseFactory.paginated(
                 activityNotApprovedListPaginatedService.cu66listNotApprovedActivitiesPaginated(page, pageSize, orderBy,
+                        orderType, search, filters, filtersValues, user),
+                SuccessfulMessages.okSuccessfully());
+    }
+
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    @GetMapping("/approved")
+    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentApprovedResponseDto>>> getApprovedActivitiesPaginatedByStudent(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
+            @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
+            @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
+            @RequestParam(required = false) String search,
+            @RequestParam(name = "filters", required = false) List<String> filters,
+            @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
+            @SessionUser User user) {
+
+        return ResponseFactory.paginated(
+                activityApprovedListPaginatedService.cu69ListApprovedActivitiesPaginated(page, pageSize, orderBy,
                         orderType, search, filters, filtersValues, user),
                 SuccessfulMessages.okSuccessfully());
     }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityApprovedListPaginatedService.java
@@ -1,0 +1,91 @@
+package trinity.play2learn.backend.activity.activity.services;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityPaginatedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityApprovedListPaginatedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterApprovedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
+import trinity.play2learn.backend.activity.activity.specs.ActivitySpecs;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+import trinity.play2learn.backend.utils.PaginationHelper;
+import trinity.play2learn.backend.utils.PaginatorUtils;
+
+@Service
+@AllArgsConstructor
+public class ActivityApprovedListPaginatedService implements IActivityApprovedListPaginatedService {
+
+    private final IStudentGetByEmailService studentGetByEmailService;
+    private final IActivityGetByStudentService activityGetByStudentService;
+    private final IActivityFilterApprovedService activityFilterApprovedService;
+    private final IActivityPaginatedRepository activityPaginatedRepository;
+    private final IActivityCreateApprovedDtosService activityCreateApprovedDtosService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedData<ActivityStudentApprovedResponseDto> cu69ListApprovedActivitiesPaginated(int page, int size,
+            String orderBy, String orderType, String search, List<String> filters, List<String> filterValues,
+            User user) {
+
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        List<Activity> activities = activityGetByStudentService.getByStudent(student);
+
+        List<Activity> approvedActivities = activityFilterApprovedService.filterByApproved(activities, student);
+
+        // Creo una lista con los ids de las actividades no aprobadas del estudiante
+        List<Long> activityIds = approvedActivities.stream()
+                .map(Activity::getId)
+                .toList();
+
+        Pageable pageable = PaginatorUtils.buildPageable(page, size, orderBy, orderType);
+        Specification<Activity> spec = Specification.where(ActivitySpecs.notDeleted());
+
+        if (search != null && !search.isBlank()) {
+            spec = spec.and(ActivitySpecs.nameContains(search));
+        }
+
+        if (filters != null && filterValues != null && filters.size() == filterValues.size()) {
+            for (int i = 0; i < filters.size(); i++) {
+                String field = filters.get(i);
+                String value = filterValues.get(i);
+
+                // Si el filtro es de materia, lo agrego a la spec, sino filtra normalmente
+                if ("subjectId".equals(field)) {
+                    spec = spec.and(ActivitySpecs.hasSubjectId(Long.valueOf(value)));
+                } else {
+
+                    spec = spec.and(ActivitySpecs.genericFilter(field, value));
+                }
+            }
+        }
+
+        // Restricción por estudiante: solo actividades dentro de la lista obtenida
+        if (!activityIds.isEmpty()) {
+            spec = spec.and((root, query, cb) -> root.get("id").in(activityIds));
+        } else {
+            // Si el estudiante no tiene actividades, devolvemos un Page vacío
+            return PaginationHelper.fromPage(Page.empty(pageable), List.of());
+        }
+
+        Page<Activity> pageResult = activityPaginatedRepository.findAll(spec, pageable);
+
+        List<ActivityStudentApprovedResponseDto> dtos = activityCreateApprovedDtosService
+                .createApprovedDtos(pageResult.getContent(), student);
+
+        return PaginationHelper.fromPage(pageResult, dtos);
+
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterApprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterApprovedService.java
@@ -1,0 +1,26 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterApprovedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetCompletedStateService;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Service
+@AllArgsConstructor
+public class ActivityFilterApprovedService implements IActivityFilterApprovedService{
+    
+    private final IActivityGetCompletedStateService activityGetCompletedStateService;
+    
+    @Override
+    public List<Activity> filterByApproved(List<Activity> activities, Student student) {
+
+        return activities
+            .stream()
+            .filter(activity -> activityGetCompletedStateService.getActivityCompletedState(activity, student) == ActivityCompletedState.APPROVED)
+            .toList();
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityApprovedListPaginatedService.java
@@ -1,0 +1,21 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IActivityApprovedListPaginatedService {
+    
+    PaginatedData<ActivityStudentApprovedResponseDto> cu69ListApprovedActivitiesPaginated(
+            int page,
+            int size,
+            String orderBy,
+            String orderType,
+            String search,
+            List<String> filters,
+            List<String> filterValues,
+            User user
+        );
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterApprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterApprovedService.java
@@ -1,0 +1,11 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityFilterApprovedService {
+    
+    List<Activity> filterByApproved(List<Activity> activities, Student student);
+}


### PR DESCRIPTION
Cree un endpoint para listar las actividades aprobadas del estudiante con paginacion. El mismo puede ser accedido unicamente por un `STUDENT` mediante la URL `/activity/student/paginated/approved`. 
Espera los siguientes parametros:

- page: Numero de pagina, por defecto 1.
- page_size: Tamaño de pagina, por defecto 10
- order_by: Atributo por el cual ordenar, por defecto id
- order_type: desc o asc, por defecto asc
- search: Busca sobre el name
- filters: Espera el nombre de un atibuto
- filtersValues:Espera el valor exacto del atributo por el cual filtrar

Los atributos por los cuales se puede filtrar son:

- id
- name
- description
- difficulty
- maxTime
- attempts
- subjectId

El endpoint devuelve un JSON como este:
```json
{
    "data": {
        "results": [
            {
                "id": 9,
                "name": "Actividad",
                "description": "Adivina la palabra",
                "difficulty": "MEDIO",
                "subjectName": "Matematica",
                "attempts": 5,
                "remainingAttempts": 5,
                "completedAt": "2025-09-04T11:30:59.391389",
                "reward": 0.0,
                "state": "APPROVED"
            },
            {
                "id": 13,
                "name": "Actividad",
                "description": "Adivina la palabra",
                "difficulty": "MEDIO",
                "subjectName": "Geografia",
                "attempts": 5,
                "remainingAttempts": 5,
                "completedAt": "2025-09-04T12:52:02.814921",
                "reward": 0.0035608253396699216,
                "state": "APPROVED"
            }
        ],
        "count": 2,
        "totalPages": 1,
        "currentPage": 1,
        "pageSize": 10
    },
    "message": "OK",
    "errors": null,
    "timestamp": "2025-09-11T14:46:20.227177400Z"
}
```