### PR TITLE
233 agregar filtrado por estado de la actividad en get notapproved por paginacion

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterByDisapprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityFilterByDisapprovedService.java
@@ -1,0 +1,40 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityFilterByDisapprovedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetLastCompletedService;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Service
+@AllArgsConstructor
+public class ActivityFilterByDisapprovedService implements IActivityFilterByDisapprovedService {
+    
+    private final IActivityGetLastCompletedService activityGetLastCompletedService;
+
+    //Filtra las actividades por desaprobadas o no desaprobadas segun el booleano.
+    @Override
+    public List<Activity> filterByDisapproved(List<Activity> activities, Student student, Boolean disapproved) {
+
+        return activities.stream()
+
+                .filter(activity -> {
+                    var lastCompleted = activityGetLastCompletedService.getLastCompleted(activity, student);
+
+                    if (lastCompleted == null) {
+                        return !disapproved; //Si no hay intentos realizados, devuelve las no desaprobadas
+                    }
+
+                    return disapproved 
+                        ? lastCompleted.getRemainingAttempts() == 0   // desaprobadas
+                        : lastCompleted.getRemainingAttempts() > 0;   // no desaprobadas
+                })
+                .toList();
+    }
+    
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterByDisapprovedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityFilterByDisapprovedService.java
@@ -1,0 +1,11 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityFilterByDisapprovedService {
+    
+    List<Activity> filterByDisapproved(List<Activity> activities, Student student, Boolean disapproved);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityPendingStrategyService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/strategyActivty/ActivityPendingStrategyService.java
@@ -23,7 +23,7 @@ public class ActivityPendingStrategyService implements IActivityCompletedStrateg
     @Transactional
     public ActivityCompletedResponseDto execute(Activity activity, Student student , Integer remainingAttempts) {
         
-        ActivityCompleted activityCompleted = ActivityCompletedMapper.toModel(activity, student, null, remainingAttempts, ActivityCompletedState.PENDING);
+        ActivityCompleted activityCompleted = ActivityCompletedMapper.toModel(activity, student, 0.0, remainingAttempts, ActivityCompletedState.PENDING);
         
         return ActivityCompletedMapper.toDto(activityCompletedRepository.save(activityCompleted));
     }


### PR DESCRIPTION
Agregue filtro en endpoint para listar las actividades no aprobadas del estudiante con paginacion (URI `GET` `/activity/student/paginated/not-approved`)
Ahora en filters, se puede mandar el filtro `disapproved`, el cual es un booleano. 
- En caso de ser `true`, devuelve las actividades desaprobadas (Todos los intentos desaprobados).
- En caso de ser `false` devuelve las actividades no desaprobadas (Minimo 1 intento restante)