### PR TITLE
fix: Se ignoran mayusculas al validar nombres en modulo ADMIN. #234

### DIFF
--- a/src/main/java/trinity/play2learn/backend/admin/course/repositories/ICourseRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/course/repositories/ICourseRepository.java
@@ -28,7 +28,7 @@ public interface ICourseRepository extends CrudRepository<Course, Long>, JpaSpec
      * @param year Año de la clase.
      * @return boolean.
      */
-    boolean existsByNameAndYear(String name, Year year);
+    boolean existsByNameIgnoreCaseAndYear(String name, Year year);
     /**
      * Busca si existe un curso por su nombre.
      *
@@ -56,7 +56,7 @@ public interface ICourseRepository extends CrudRepository<Course, Long>, JpaSpec
 
     Optional<Course> findByIdAndDeletedAtIsNull(Long id);
 
-    boolean existsByNameAndYearAndIdNot(String name, Year year , Long id);
+    boolean existsByNameIgnoreCaseAndYearAndIdNot(String name, Year year , Long id);
 
     int countByDeletedAtIsNull();
 

--- a/src/main/java/trinity/play2learn/backend/admin/course/services/commons/CourseExistByService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/course/services/commons/CourseExistByService.java
@@ -27,7 +27,7 @@ public class CourseExistByService implements ICourseExistByService {
      */
     @Override
     public boolean validate(String name, Year year) {
-        return courseRepository.existsByNameAndYear(name, year);
+        return courseRepository.existsByNameIgnoreCaseAndYear(name, year);
     }
     /**
      * Valida si ya existe un curso con el mismo id.
@@ -53,7 +53,7 @@ public class CourseExistByService implements ICourseExistByService {
     //Valida si ya existe un curso con ese nombre en ese año, exceptuando el curso pasado por ID
     @Override
     public void validateExceptId(Long id, String name, Year year) {
-        if (courseRepository.existsByNameAndYearAndIdNot(name, year, id)) {
+        if (courseRepository.existsByNameIgnoreCaseAndYearAndIdNot(name, year, id)) {
             
             throw new ConflictException(
                 ConflictExceptionMessages.resourceAlreadyExists(

--- a/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/repositories/ISubjectRepository.java
@@ -16,9 +16,9 @@ public interface ISubjectRepository extends CrudRepository<Subject , Long> {
     
     Optional<Subject> findByIdAndDeletedAtIsNotNull(Long id);
     
-    Boolean existsByNameAndCourse(String name, Course course);
+    Boolean existsByNameIgnoreCaseAndCourse(String name, Course course);
 
-    Boolean existsByNameAndCourseAndIdNot(String name, Course course , Long id);
+    Boolean existsByNameIgnoreCaseAndCourseAndIdNot(String name, Course course , Long id);
 
     List<Subject> findAllByDeletedAtIsNull();
 

--- a/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/SubjectExistsByNameAndCourseService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/subject/services/commons/SubjectExistsByNameAndCourseService.java
@@ -17,7 +17,7 @@ public class SubjectExistsByNameAndCourseService implements ISubjectExistsByName
     @Override
     public void existByNameAndCourse(String name , Course course) {
 
-        if (subjectRepository.existsByNameAndCourse(name, course)) {
+        if (subjectRepository.existsByNameIgnoreCaseAndCourse(name, course)) {
             throw new ConflictException(
                 ConflictExceptionMessages.resourceAlreadyExistsByName(
                     "Materia",
@@ -31,7 +31,7 @@ public class SubjectExistsByNameAndCourseService implements ISubjectExistsByName
     @Override
     public void existByNameAndCourseAndIdNot(String name, Course course, Long id) {
 
-        if (subjectRepository.existsByNameAndCourseAndIdNot(name, course, id)) {
+        if (subjectRepository.existsByNameIgnoreCaseAndCourseAndIdNot(name, course, id)) {
             throw new ConflictException(
                 ConflictExceptionMessages.resourceAlreadyExistsByName(
                     "Materia",

--- a/src/main/java/trinity/play2learn/backend/admin/year/repositories/IYearRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/year/repositories/IYearRepository.java
@@ -24,12 +24,11 @@ public interface IYearRepository extends CrudRepository<Year, Long> {
      * @param name Nombre del año.
      * @return boolean.
      */
-    boolean existsByName(String name);
-
+    boolean existsByNameIgnoreCase(String name);
 
     Iterable<Year> findAllByDeletedAtIsNull();
 
-    boolean existsByNameAndIdNot(String name, Long id);
+    boolean existsByNameIgnoreCaseAndIdNot(String name, Long id);
 
     int countByDeletedAtIsNull();
     

--- a/src/main/java/trinity/play2learn/backend/admin/year/services/commons/YearExistService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/year/services/commons/YearExistService.java
@@ -25,7 +25,7 @@ public class YearExistService implements IYearExistService {
      */
     @Override
     public boolean validate(String name) {
-        return yearRepository.existsByName(name);
+        return yearRepository.existsByNameIgnoreCase(name);
     }
     /**
      * Valida si ya existe un año con el mismo id.
@@ -40,7 +40,7 @@ public class YearExistService implements IYearExistService {
 
     @Override
     public void validateExceptId(String name, Long id) {
-        if (yearRepository.existsByNameAndIdNot(name, id)) {
+        if (yearRepository.existsByNameIgnoreCaseAndIdNot(name, id)) {
             throw new ConflictException(
                 ConflictExceptionMessages.resourceAlreadyExistsByName("Año", name)
             );   


### PR DESCRIPTION
Al crear o actualizar años, cursos o materias se ignoran las mayusculas en la validacion de los nombres repetidos.
De esta forma, no puede existir por ejemplo en el mismo curso una materia llamada `matematica` y otra llamada `MATEMATICA` 