### PR TITLE
feat: Endpoint para eliminar un beneficio. #257

### DIFF
--- a/src/main/java/trinity/play2learn/backend/benefits/controllers/BenefitDeleteController.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/controllers/BenefitDeleteController.java
@@ -1,0 +1,32 @@
+package trinity.play2learn.backend.benefits.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.benefits.services.interfaces.IBenefitDeleteService;
+import trinity.play2learn.backend.configs.annotations.SessionRequired;
+import trinity.play2learn.backend.configs.annotations.SessionUser;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+import trinity.play2learn.backend.user.models.User;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/benefits/teacher")
+public class BenefitDeleteController {
+    
+    private final IBenefitDeleteService benefitDeleteService;
+
+    @DeleteMapping("/{id}")
+    @SessionRequired(roles = {Role.ROLE_TEACHER})
+    public ResponseEntity<BaseResponse<Void>> deleteBenefit(@SessionUser User user, @PathVariable Long id) {
+        
+        benefitDeleteService.cu94DeleteBenefit(user, id);
+        return ResponseFactory.noContent("Beneficio eliminado con exito");
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/benefits/services/BenefitDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/services/BenefitDeleteService.java
@@ -1,0 +1,76 @@
+package trinity.play2learn.backend.benefits.services;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.admin.teacher.services.interfaces.ITeacherGetByEmailService;
+import trinity.play2learn.backend.benefits.models.Benefit;
+import trinity.play2learn.backend.benefits.models.BenefitPurchase;
+import trinity.play2learn.backend.benefits.models.BenefitPurchaseState;
+import trinity.play2learn.backend.benefits.repositories.IBenefitPurchaseRepository;
+import trinity.play2learn.backend.benefits.repositories.IBenefitRepository;
+import trinity.play2learn.backend.benefits.services.interfaces.IBenefitDeleteService;
+import trinity.play2learn.backend.benefits.services.interfaces.IBenefitGetByIdService;
+import trinity.play2learn.backend.configs.exceptions.ConflictException;
+import trinity.play2learn.backend.economy.transaction.models.TransactionActor;
+import trinity.play2learn.backend.economy.transaction.models.TypeTransaction;
+import trinity.play2learn.backend.economy.transaction.services.interfaces.ITransactionGenerateService;
+import trinity.play2learn.backend.user.models.User;
+
+@Service
+@AllArgsConstructor
+public class BenefitDeleteService implements IBenefitDeleteService {
+    
+    private final IBenefitRepository benefitRepository;
+    private final ITeacherGetByEmailService teacherGetByEmailService;
+    private final IBenefitGetByIdService benefitGetByIdService;
+    private final IBenefitPurchaseRepository benefitPurchaseRepository;
+    private final ITransactionGenerateService transactionGenerateService;
+
+    @Override
+    @Transactional
+    public void cu94DeleteBenefit(User user, Long id) {
+        
+        Teacher teacher = teacherGetByEmailService.getByEmail(user.getEmail());
+        
+        Benefit benefit = benefitGetByIdService.getById(id);
+
+        if (!benefit.getSubject().getTeacher().equals(teacher)) {
+            throw new ConflictException("No es posible eliminar este beneficio ya que no pertenece al docente");
+        }
+
+        if (!benefit.isExpired()) { //Si esta expirado salta la logica de reembolso
+            List<BenefitPurchase> benefitPurchases = benefitPurchaseRepository.findByBenefit(benefit);
+
+            for (BenefitPurchase benefitPurchase : benefitPurchases) {
+                if (benefitPurchase.getState() != BenefitPurchaseState.USED) {
+
+                    //Si un estudiante tiene el beneficio comprado o solicito su uso, se le reemboalza lo que pago
+                    transactionGenerateService.generate(
+                        TypeTransaction.REEMBOLSO, 
+                        (double) benefit.getCost(), 
+                        "Reembolso de beneficio", 
+                        TransactionActor.SISTEMA, 
+                        TransactionActor.ESTUDIANTE, 
+                        benefitPurchase.getStudent().getWallet(), 
+                        null, 
+                        null, 
+                        benefit, 
+                        null);
+                }
+            }
+
+
+        }
+        benefit.setDeletedAt(LocalDateTime.now());
+
+        benefitRepository.save(benefit);
+    }
+    
+    
+}

--- a/src/main/java/trinity/play2learn/backend/benefits/services/interfaces/IBenefitDeleteService.java
+++ b/src/main/java/trinity/play2learn/backend/benefits/services/interfaces/IBenefitDeleteService.java
@@ -1,0 +1,8 @@
+package trinity.play2learn.backend.benefits.services.interfaces;
+
+import trinity.play2learn.backend.user.models.User;
+
+public interface IBenefitDeleteService {
+    
+    void cu94DeleteBenefit(User user, Long id);
+}

--- a/src/main/java/trinity/play2learn/backend/economy/transaction/services/strategyTransaction/ReembolsoTransactionService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/transaction/services/strategyTransaction/ReembolsoTransactionService.java
@@ -7,31 +7,61 @@ import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.admin.subject.models.Subject;
 import trinity.play2learn.backend.benefits.models.Benefit;
+import trinity.play2learn.backend.economy.reserve.models.Reserve;
+import trinity.play2learn.backend.economy.reserve.services.interfaces.IReserveFindLastService;
+import trinity.play2learn.backend.economy.reserve.services.interfaces.IReserveModifyService;
+import trinity.play2learn.backend.economy.transaction.mappers.TransactionMapper;
 import trinity.play2learn.backend.economy.transaction.models.Transaction;
 import trinity.play2learn.backend.economy.transaction.models.TransactionActor;
+import trinity.play2learn.backend.economy.transaction.repositories.ITransactionRepository;
 import trinity.play2learn.backend.economy.transaction.services.interfaces.ITransactionStrategyService;
 import trinity.play2learn.backend.economy.wallet.models.Wallet;
+import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletAddAmountService;
 import trinity.play2learn.backend.investment.stock.models.Order;
 
-@Service ("REEMBOLSO")
+@Service("REEMBOLSO")
 @AllArgsConstructor
 public class ReembolsoTransactionService implements ITransactionStrategyService {
 
+    private final IReserveFindLastService findLastReserveService;
+    private final ITransactionRepository transaccionRepository;
+    private final IWalletAddAmountService addAmountWalletService;
+    private final IReserveModifyService modifyReserveService;
+    
     @Override
     @Transactional
     public Transaction execute(
-        Double amount, 
-        String description, 
-        TransactionActor origin, 
-        TransactionActor destination,
-        Wallet wallet, 
-        Subject subject,
-        Activity activity,
-        Benefit benefit,
-        Order order
-        ) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+            Double amount,
+            String description,
+            TransactionActor origin,
+            TransactionActor destination,
+            Wallet wallet,
+            Subject subject,
+            Activity activity,
+            Benefit benefit,
+            Order order) {
+
+        Reserve reserve = findLastReserveService.get();
+
+        Transaction transaccion = TransactionMapper.toModel(
+                amount,
+                description,
+                origin,
+                destination,
+                wallet,
+                null,
+                null,
+                benefit,
+                null,
+                reserve);
+
+        Transaction transaccionSaved = transaccionRepository.save(transaccion);
+
+        addAmountWalletService.execute(wallet, amount);
+
+        modifyReserveService.moveToCirculation(amount, reserve);
+
+        return transaccionSaved;
     }
-    
+
 }


### PR DESCRIPTION
Endpoint que permite a un docente eliminar un beneficio. Puede ser accedido solo por un docente mediante la URI `DELETE /benefits/teacher/{id}`.

- El endpoint valida que el docente este asignado a la materia del beneficio. 
- En caso de que el beneficio no este expirado, se reembolsara a los estudiantes que tengan el beneficio en estado PURCHASED o USE_REQUESTED.