### PR TITLE
329 visualizar resultados de actividad

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityGetStudentResultsController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityGetStudentResultsController.java
@@ -1,0 +1,32 @@
+package trinity.play2learn.backend.activity.activity.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityCompleted.ActivityStudentResultsResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetStudentResultsService;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
+import trinity.play2learn.backend.configs.annotations.SessionRequired;
+import trinity.play2learn.backend.configs.annotations.SessionUser;
+import trinity.play2learn.backend.user.models.Role;
+import trinity.play2learn.backend.user.models.User;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/activity/completed")
+public class ActivityGetStudentResultsController {
+    
+    private final IActivityGetStudentResultsService activityGetStudentResultsService;
+    
+    @GetMapping("/results/{activityId}")
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    public ResponseEntity<BaseResponse<ActivityStudentResultsResponseDto>> getStudentResults(@PathVariable Long activityId, @SessionUser User user) {
+        return ResponseFactory.ok(activityGetStudentResultsService.cu125GetStudentResults(activityId, user), SuccessfulMessages.okSuccessfully());
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityCompleted/ActivityCompletedRequestDto.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityCompleted/ActivityCompletedRequestDto.java
@@ -17,4 +17,16 @@ public class ActivityCompletedRequestDto {
 
     @NotNull(message = ValidationMessages.NOT_NULL_STATE)
     private ActivityCompletedState state; //APPROVED, DISAPPROVED, PENDING
+
+    @NotNull(message = ValidationMessages.NOT_NULL_SCORE)
+    private int score;
+
+    @NotNull(message = ValidationMessages.NOT_NULL_CORRECT_ANSWERS)
+    private int correctAnswers;
+
+    @NotNull(message = ValidationMessages.NOT_NULL_INCORRECT_ANSWERS)
+    private int incorrectAnswers;
+
+    @NotNull(message = ValidationMessages.NOT_NULL_UNANSWERED)
+    private int unanswered;
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityCompleted/ActivityStudentResultsResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityCompleted/ActivityStudentResultsResponseDto.java
@@ -1,0 +1,25 @@
+package trinity.play2learn.backend.activity.activity.dtos.activityCompleted;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ActivityStudentResultsResponseDto {
+    
+    private Long id;
+    private Long activityId;
+    private ActivityCompletedState state;
+    private int attempts;
+    private Double reward;
+    private long completedTimeInSeconds;
+    private int score;
+    private int correctAnswers;
+    private int incorrectAnswers;
+    private int unanswered;
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityCompletedMapper.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityCompletedMapper.java
@@ -1,6 +1,9 @@
 package trinity.play2learn.backend.activity.activity.mappers;
 
+import java.time.Duration;
+
 import trinity.play2learn.backend.activity.activity.dtos.activityCompleted.ActivityCompletedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityCompleted.ActivityStudentResultsResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentGetResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
@@ -10,7 +13,9 @@ import trinity.play2learn.backend.admin.student.models.Student;
 
 public class ActivityCompletedMapper {
     
-    public static ActivityCompleted toModel(Activity activity, Student student, Double reward, Integer remainingAttempts, ActivityCompletedState state, NoLudicaAttempt noLudicaAttempt) {
+    public static ActivityCompleted toModel(
+        Activity activity, Student student, Double reward, Integer remainingAttempts, ActivityCompletedState state, 
+        NoLudicaAttempt noLudicaAttempt, int score, int correctAnswers, int incorrectAnswers, int unanswered) {
 
         return ActivityCompleted.builder()
             .activity(activity)
@@ -19,6 +24,10 @@ public class ActivityCompletedMapper {
             .remainingAttempts(remainingAttempts)
             .state(state)
             .noLudicaAttempt(noLudicaAttempt)
+            .score(score)
+            .correctAnswers(correctAnswers)
+            .incorrectAnswers(incorrectAnswers)
+            .unanswered(unanswered)
             .build();
     }
 
@@ -43,4 +52,20 @@ public class ActivityCompletedMapper {
             .build();
     }
 
+    public static ActivityStudentResultsResponseDto toStudentResultsDto(
+        ActivityCompleted activityCompleted, int attempts) {
+
+        return ActivityStudentResultsResponseDto.builder()
+            .id(activityCompleted.getId())
+            .activityId(activityCompleted.getActivity().getId())
+            .state(activityCompleted.getState())
+            .attempts(attempts)
+            .reward(activityCompleted.getReward() == null ? 0.0 : (Math.round(activityCompleted.getReward() * 100.0) / 100.0))
+            .completedTimeInSeconds(Duration.between(activityCompleted.getStartedAt(), activityCompleted.getCompletedAt()).getSeconds())
+            .score(activityCompleted.getScore())
+            .correctAnswers(activityCompleted.getCorrectAnswers())
+            .incorrectAnswers(activityCompleted.getIncorrectAnswers())
+            .unanswered(activityCompleted.getUnanswered())
+            .build();
+    }
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/models/activityCompleted/ActivityCompleted.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/models/activityCompleted/ActivityCompleted.java
@@ -44,6 +44,14 @@ public class ActivityCompleted {
     @NotNull
     private Student student;
 
+    private int score; //Puntaje obtenido en la actividad
+
+    private int correctAnswers; //Cantidad de respuestas correctas
+
+    private int incorrectAnswers; //Cantidad de respuestas incorrectas
+
+    private int unanswered; //Cantidad de respuestas sin responder
+    
     private LocalDateTime completedAt;
 
     private LocalDateTime startedAt;

--- a/src/main/java/trinity/play2learn/backend/activity/activity/models/activityCompleted/ActivityCompleted.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/models/activityCompleted/ActivityCompleted.java
@@ -3,7 +3,9 @@ package trinity.play2learn.backend.activity.activity.models.activityCompleted;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+import io.micrometer.common.lang.Nullable;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -44,13 +46,17 @@ public class ActivityCompleted {
     @NotNull
     private Student student;
 
-    private int score; //Puntaje obtenido en la actividad
+    @Column(nullable = true)
+    private Integer score; //Puntaje obtenido en la actividad
 
-    private int correctAnswers; //Cantidad de respuestas correctas
+    @Column(nullable = true)
+    private Integer correctAnswers; //Cantidad de respuestas correctas
 
-    private int incorrectAnswers; //Cantidad de respuestas incorrectas
+    @Column(nullable = true)
+    private Integer incorrectAnswers; //Cantidad de respuestas incorrectas
 
-    private int unanswered; //Cantidad de respuestas sin responder
+    @Column(nullable = true)
+    private Integer unanswered; //Cantidad de respuestas sin responder
     
     private LocalDateTime completedAt;
 

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityCompletedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityCompletedService.java
@@ -58,20 +58,36 @@ public class ActivityCompletedService implements IActivityCompletedService {
             throw new ConflictException("La actividad ya ha sido aprobada.");
         }
 
-        Optional<ActivityCompleted> lastStarted = activityCompletedGetLastStartedService.getLastStartedInProgress(activity, student);
+        Optional<ActivityCompleted> lastStartedOp = activityCompletedGetLastStartedService.getLastStartedInProgress(activity, student);
         
-        if (lastStarted.isEmpty()){
+        if (lastStartedOp.isEmpty()){
             throw new ConflictException("No se puede actualizar la actividad ya que no se encuentra en curso.");
         }
 
+        //Valido consistencia entre estado y score
+        if (activityCompletedRequestDto.getState() == ActivityCompletedState.APPROVED && activityCompletedRequestDto.getScore() < 60) {
+            throw new ConflictException("La actividad no puede ser aprobada con un puntaje menor a 60.");
+        }
+
+        if (activityCompletedRequestDto.getState() == ActivityCompletedState.DISAPPROVED && activityCompletedRequestDto.getScore() >= 60) {
+            throw new ConflictException("La actividad no puede ser desaprobada con un puntaje mayor o igual a 60.");
+        }
+
         // Si el tiempo de intento es mayor al tiempo maximo de la actividad, se desaprueba automaticamente
-        if (this.calculateTimeAttemp(lastStarted.get().getStartedAt()) > activity.getMaxTime()){
+        if (this.calculateTimeAttemp(lastStartedOp.get().getStartedAt()) > activity.getMaxTime()){
             activityCompletedRequestDto.setState(ActivityCompletedState.DISAPPROVED);
         }
+        
+        ActivityCompleted lastStarted = lastStartedOp.get();
+
+        lastStarted.setScore(activityCompletedRequestDto.getScore());
+        lastStarted.setCorrectAnswers(activityCompletedRequestDto.getCorrectAnswers());
+        lastStarted.setIncorrectAnswers(activityCompletedRequestDto.getIncorrectAnswers());
+        lastStarted.setUnanswered(activityCompletedRequestDto.getUnanswered());
 
         IActivityCompletedStrategyService strategyService = activityCompletedStrategyServiceMap.get(activityCompletedRequestDto.getState().name());
 
-        return strategyService.execute(lastStarted.get());
+        return strategyService.execute(lastStarted);
     }
 
 

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityGetStudentResultsService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityGetStudentResultsService.java
@@ -1,0 +1,43 @@
+package trinity.play2learn.backend.activity.activity.services;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityCompleted.ActivityStudentResultsResponseDto;
+import trinity.play2learn.backend.activity.activity.mappers.ActivityCompletedMapper;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCountCompletedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByIdService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetLastCompletedService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetStudentResultsService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.user.models.User;
+
+@Service
+@AllArgsConstructor
+public class ActivityGetStudentResultsService implements IActivityGetStudentResultsService {
+    
+    private final IStudentGetByEmailService studentGetByEmailService;
+    private final IActivityGetLastCompletedService activityGetLastCompletedService;
+    private final IActivityGetByIdService activityGetByIdService;
+    private final IActivityCountCompletedService activityCountCompletedService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ActivityStudentResultsResponseDto cu125GetStudentResults(Long activityId, User user) {
+        
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        Activity activity = activityGetByIdService.findActivityById(activityId);
+
+        ActivityCompleted activityCompleted = activityGetLastCompletedService.getLastCompleted(activity, student);
+
+        int attempts = activityCountCompletedService.countCompletedByActivityAndStudent(activity, student);
+
+        return ActivityCompletedMapper.toStudentResultsDto(activityCompleted, attempts);
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityStartService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/ActivityStartService.java
@@ -92,7 +92,11 @@ public class ActivityStartService implements IActivityStartService{
                     null, 
                     remainingAttempts, 
                     ActivityCompletedState.IN_PROGRESS,
-                    null
+                    null,
+                    0,
+                    0,
+                    0,
+                    0
                 )
             )
         );

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityGetStudentResultsService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityGetStudentResultsService.java
@@ -1,0 +1,9 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import trinity.play2learn.backend.activity.activity.dtos.activityCompleted.ActivityStudentResultsResponseDto;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IActivityGetStudentResultsService {
+    
+    ActivityStudentResultsResponseDto cu125GetStudentResults(Long activityId, User user);
+}

--- a/src/main/java/trinity/play2learn/backend/configs/messages/ValidationMessages.java
+++ b/src/main/java/trinity/play2learn/backend/configs/messages/ValidationMessages.java
@@ -82,6 +82,11 @@ public class ValidationMessages {
     public static final String NOT_NULL_ACTIVITY_ID = "El id de la actividad no puede estar vacio.";
     public static final String NOT_NULL_STATE = "El estado no puede estar vacio.";
 
+    public static final String NOT_NULL_SCORE = "El puntaje no puede estar vacio.";
+    public static final String NOT_NULL_CORRECT_ANSWERS = "La cantidad de respuestas correctas no puede estar vacia.";
+    public static final String NOT_NULL_INCORRECT_ANSWERS = "La cantidad de respuestas incorrectas no puede estar vacia.";
+    public static final String NOT_NULL_UNANSWERED = "La cantidad de respuestas sin responder no puede estar vacia.";
+    
     //------------------------------------- ARBOL DE DECISION ------------------------------------------------------
     public static final String NOT_NULL_DECISION_TREE = "El arbol de decision no puede estar vacio.";
     public static final String OPTIONS_SIZE = "Una decisión debe tener exactamente 2 opciones o ninguna.";

--- a/src/main/java/trinity/play2learn/backend/notification/models/Notification.java
+++ b/src/main/java/trinity/play2learn/backend/notification/models/Notification.java
@@ -3,6 +3,8 @@ package trinity.play2learn.backend.notification.models;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +29,8 @@ public class Notification {
     private Long id;
 
     private String title;
-
+    
+    @Enumerated(EnumType.STRING)
     private NotificationType type;
 
     private boolean read;


### PR DESCRIPTION
### Cambios en endpoint actividad completada
Ahora el endpoint accedido mediante la URI `POST /activity/completed` acepta 4 nuevos parametros en el DTO:
- int score;
- int correctAnswers;
- int incorrectAnswers;
- int unanswered;

Se valida que el score corresponda al estado(Se aprueba con 60 puntos)

### Endpoint para obtener los resultados de una actividad
Endpoint que permite a un estudiante ver los resultados del ultimo intento de una actividad. El mismo es accedido mediante la URI `GET /activity/completed/results/{activityId}` y devuelve un DTO como este:
```json
{
    "data": {
        "id": 141,
        "activityId": 36,
        "state": "APPROVED",
        "attempts": 1,
        "reward": 161.29,
        "completedTimeInSeconds": 24,
        "score": 80,
        "correctAnswers": 4,
        "incorrectAnswers": 1,
        "unanswered": 0
    },
    "message": "OK",
    "errors": null,
    "timestamp": "2025-12-08T19:08:54.366176100Z"
}
```