### PR TITLE
355 listar actividades pendientes de correcion

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListApproveByStudentService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListNotApprovedByStudentService;
@@ -24,23 +24,26 @@ import trinity.play2learn.backend.user.models.User;
 @AllArgsConstructor
 @RequestMapping("/activity/student")
 public class ActivityListByStudentController {
-    
+
     private final IActivityListNotApprovedByStudentService activityGetNotApprovedByStudentService;
     private final IActivityListApproveByStudentService activityGetApprovedByStudentService;
 
     @GetMapping("/not-approved")
-    @SessionRequired(roles = {Role.ROLE_STUDENT})
-    public ResponseEntity<BaseResponse<List<ActivityStudentNotApprovedResponseDto>>> listNotApprovedActivities(@SessionUser User user) {
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    public ResponseEntity<BaseResponse<List<ActivityStudentNotApprovedResponseDto>>> listNotApprovedActivities(
+            @SessionUser User user) {
 
-        return ResponseFactory.ok(activityGetNotApprovedByStudentService.cu62ListNotApprovedActivitiesByStudent(user), SuccessfulMessages.okSuccessfully());
+        return ResponseFactory.ok(activityGetNotApprovedByStudentService.cu62ListNotApprovedActivitiesByStudent(user),
+                SuccessfulMessages.okSuccessfully());
     }
 
     @GetMapping("/approved")
-    @SessionRequired(roles = {Role.ROLE_STUDENT})
-    public ResponseEntity<BaseResponse<List<ActivityStudentApprovedResponseDto>>> listApprovedActivities(@SessionUser User user) {
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    public ResponseEntity<BaseResponse<List<ActivityStudentStateResponseDto>>> listApprovedActivities(
+            @SessionUser User user) {
 
-        return ResponseFactory.ok(activityGetApprovedByStudentService.cu63ListApprovedActivitiesByStudent(user), SuccessfulMessages.okSuccessfully());
+        return ResponseFactory.ok(activityGetApprovedByStudentService.cu63ListApprovedActivitiesByStudent(user),
+                SuccessfulMessages.okSuccessfully());
     }
-
 
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityApprovedListPaginatedService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityNotApprovedListPaginatedService;
@@ -27,42 +27,44 @@ import trinity.play2learn.backend.user.models.User;
 @AllArgsConstructor
 public class ActivityListPaginatedByStudentController {
 
-    private final IActivityNotApprovedListPaginatedService activityNotApprovedListPaginatedService;
-    private final IActivityApprovedListPaginatedService activityApprovedListPaginatedService;
-    
-    @SessionRequired(roles = { Role.ROLE_STUDENT })
-    @GetMapping("/not-approved")
-    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentNotApprovedResponseDto>>> getNotApprovedActivitiesPaginatedByStudent(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
-            @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
-            @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
-            @RequestParam(required = false) String search,
-            @RequestParam(name = "filters", required = false) List<String> filters,
-            @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
-            @SessionUser User user) {
+        private final IActivityNotApprovedListPaginatedService activityNotApprovedListPaginatedService;
+        private final IActivityApprovedListPaginatedService activityApprovedListPaginatedService;
 
-        return ResponseFactory.paginated(
-                activityNotApprovedListPaginatedService.cu66listNotApprovedActivitiesPaginated(page, pageSize, orderBy,
-                        orderType, search, filters, filtersValues, user),
-                SuccessfulMessages.okSuccessfully());
-    }
+        @SessionRequired(roles = { Role.ROLE_STUDENT })
+        @GetMapping("/not-approved")
+        public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentNotApprovedResponseDto>>> getNotApprovedActivitiesPaginatedByStudent(
+                        @RequestParam(defaultValue = "1") int page,
+                        @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
+                        @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
+                        @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
+                        @RequestParam(required = false) String search,
+                        @RequestParam(name = "filters", required = false) List<String> filters,
+                        @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
+                        @SessionUser User user) {
 
-    @SessionRequired(roles = { Role.ROLE_STUDENT })
-    @GetMapping("/approved")
-    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentApprovedResponseDto>>> getApprovedActivitiesPaginatedByStudent(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
-            @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
-            @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
-            @RequestParam(required = false) String search,
-            @RequestParam(name = "filters", required = false) List<String> filters,
-            @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
-            @SessionUser User user) {
+                return ResponseFactory.paginated(
+                                activityNotApprovedListPaginatedService.cu66listNotApprovedActivitiesPaginated(page,
+                                                pageSize, orderBy,
+                                                orderType, search, filters, filtersValues, user),
+                                SuccessfulMessages.okSuccessfully());
+        }
 
-        return ResponseFactory.paginated(
-                activityApprovedListPaginatedService.cu69ListApprovedActivitiesPaginated(page, pageSize, orderBy,
-                        orderType, search, filters, filtersValues, user),
-                SuccessfulMessages.okSuccessfully());
-    }
+        @SessionRequired(roles = { Role.ROLE_STUDENT })
+        @GetMapping("/approved")
+        public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentStateResponseDto>>> getApprovedActivitiesPaginatedByStudent(
+                        @RequestParam(defaultValue = "1") int page,
+                        @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
+                        @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
+                        @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
+                        @RequestParam(required = false) String search,
+                        @RequestParam(name = "filters", required = false) List<String> filters,
+                        @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
+                        @SessionUser User user) {
+
+                return ResponseFactory.paginated(
+                                activityApprovedListPaginatedService.cu69ListApprovedActivitiesPaginated(page, pageSize,
+                                                orderBy,
+                                                orderType, search, filters, filtersValues, user),
+                                SuccessfulMessages.okSuccessfully());
+        }
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPendingPaginatedController.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPendingPaginatedController.java
@@ -1,0 +1,50 @@
+package trinity.play2learn.backend.activity.activity.controllers;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListPendingPaginatedService;
+import trinity.play2learn.backend.configs.annotations.SessionRequired;
+import trinity.play2learn.backend.configs.annotations.SessionUser;
+import trinity.play2learn.backend.configs.messages.SuccessfulMessages;
+import trinity.play2learn.backend.configs.response.BaseResponse;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.configs.response.ResponseFactory;
+import trinity.play2learn.backend.user.models.Role;
+import trinity.play2learn.backend.user.models.User;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+@RestController
+@RequestMapping("/activity/student/pending")
+@AllArgsConstructor
+public class ActivityListPendingPaginatedController {
+    
+    private final IActivityListPendingPaginatedService activityListPendingPaginatedService;
+
+    @SessionRequired(roles = { Role.ROLE_STUDENT })
+    @GetMapping("/paginated")
+    public ResponseEntity<BaseResponse<PaginatedData<ActivityStudentStateResponseDto>>> listPendingByStudentPaginated(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(name = "page_size", defaultValue = "10") int pageSize,
+            @RequestParam(name = "order_by", defaultValue = "id") String orderBy,
+            @RequestParam(name = "order_type", defaultValue = "asc") String orderType,
+            @RequestParam(required = false) String search,
+            @RequestParam(name = "filters", required = false) List<String> filters,
+            @RequestParam(name = "filtersValues", required = false) List<String> filtersValues,
+            @SessionUser User user) {
+
+        return ResponseFactory.paginated(
+                activityListPendingPaginatedService.cu131ListPendingActivitiesByStudentPaginated(page, pageSize, orderBy,
+                        orderType, search, filters, filtersValues, user),
+                SuccessfulMessages.okSuccessfully());
+    }
+    
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentStateResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentStateResponseDto.java
@@ -11,18 +11,17 @@ import trinity.play2learn.backend.activity.activity.models.activityCompleted.Act
 @Data
 @Builder
 @AllArgsConstructor
-public class ActivityStudentApprovedResponseDto {
-    
+public class ActivityStudentStateResponseDto {
+
     private Long id;
-    private String name; 
+    private String name;
     private String description;
     private Difficulty difficulty;
     private Long subjectId;
     private String subjectName;
     private int attempts;
-    private Integer remainingAttempts; //Intentos restantes del estudiante en la actividad
+    private Integer remainingAttempts; // Intentos restantes del estudiante en la actividad
     private LocalDateTime completedAt;
     private Double reward;
-    private ActivityCompletedState state; //APPROVE
+    private ActivityCompletedState state; // APPROVE, PENDING, DISAPPROVED
 }
-

--- a/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
@@ -3,7 +3,7 @@ package trinity.play2learn.backend.activity.activity.mappers;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentCountResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentGetResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
@@ -38,10 +38,10 @@ public class ActivityMapper {
                                 .build();
         }
 
-        public static ActivityStudentApprovedResponseDto toApprovedDto(Activity activity, Integer remainingAttempts,
-                        Double reward, LocalDateTime completedAt) {
+        public static ActivityStudentStateResponseDto toStudentStateDto(Activity activity, Integer remainingAttempts,
+                        Double reward, LocalDateTime completedAt, ActivityCompletedState state) {
 
-                return ActivityStudentApprovedResponseDto.builder()
+                return ActivityStudentStateResponseDto.builder()
                                 .id(activity.getId())
                                 .name(activity.getName())
                                 .description(activity.getDescription())
@@ -52,7 +52,7 @@ public class ActivityMapper {
                                 .remainingAttempts(remainingAttempts)
                                 .completedAt(completedAt)
                                 .reward(reward)
-                                .state(ActivityCompletedState.APPROVED)
+                                .state(state)
                                 .build();
         }
 
@@ -66,7 +66,8 @@ public class ActivityMapper {
                                 .build();
         }
 
-        public static ActivityTeacherSimpleDto toSimpleDto(Activity activity, ActivityStatus status, LocalDateTime date) {
+        public static ActivityTeacherSimpleDto toSimpleDto(Activity activity, ActivityStatus status,
+                        LocalDateTime date) {
                 return ActivityTeacherSimpleDto.builder()
                                 .id(activity.getId())
                                 .name(activity.getName())
@@ -81,7 +82,8 @@ public class ActivityMapper {
                                 .build();
         }
 
-        public static ActivityTeacherGetResponseDto toTeacherGetDto(Activity activity, ActivityStatus status, int studentsAttemptedCount, int studentsApprovedCount,
+        public static ActivityTeacherGetResponseDto toTeacherGetDto(Activity activity, ActivityStatus status,
+                        int studentsAttemptedCount, int studentsApprovedCount,
                         Double averageCompletionTime, Double participationPercentage, Double successPercentage,
                         List<ActivityStudentGetResponseDto> activityStudentGetDtos, Double reward) {
                 return ActivityTeacherGetResponseDto.builder()
@@ -92,7 +94,7 @@ public class ActivityMapper {
                                 .endDate(activity.getEndDate())
                                 .status(status)
                                 .difficulty(activity.getDifficulty())
-                                .maxTime(activity.getMaxTime()) 
+                                .maxTime(activity.getMaxTime())
                                 .subjectName(activity.getSubject().getName())
                                 .courseName(activity.getSubject().getCourse().getFullName())
                                 .attempts(activity.getAttempts())

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateApprovedDtosService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.mappers.ActivityMapper;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
@@ -18,35 +18,35 @@ import trinity.play2learn.backend.admin.student.models.Student;
 @Service
 @AllArgsConstructor
 public class ActivityCreateApprovedDtosService implements IActivityCreateApprovedDtosService {
-    
+
     private final IActivityGetLastCompletedService activityGetLastCompletedService;
 
     @Override
-    public List<ActivityStudentApprovedResponseDto> createApprovedDtos(List<Activity> activities, Student student) {
-        
-        List<ActivityStudentApprovedResponseDto> activitiesDto = new ArrayList<>();
+    public List<ActivityStudentStateResponseDto> createApprovedDtos(List<Activity> activities, Student student) {
+
+        List<ActivityStudentStateResponseDto> activitiesDto = new ArrayList<>();
 
         for (Activity activity : activities) {
 
             ActivityCompleted lastCompleted = activityGetLastCompletedService.getLastCompleted(activity, student);
-            
+
             if (lastCompleted == null) {
 
                 continue;
             }
 
             if (lastCompleted.getState() != ActivityCompletedState.APPROVED) {
-                
-                continue; //Salta a la siguiente iteracion
+
+                continue; // Salta a la siguiente iteracion
             }
-            
-            activitiesDto.add(ActivityMapper.toApprovedDto(activity, lastCompleted.getRemainingAttempts(), lastCompleted.getReward(), lastCompleted.getCompletedAt()));
+
+            activitiesDto.add(ActivityMapper.toStudentStateDto(activity, lastCompleted.getRemainingAttempts(),
+                    lastCompleted.getReward(), lastCompleted.getCompletedAt(), lastCompleted.getState()));
 
         }
 
         return activitiesDto;
 
     }
-    
-    
+
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityApprovedListPaginatedService.java
@@ -2,13 +2,13 @@ package trinity.play2learn.backend.activity.activity.services.interfaces;
 
 import java.util.List;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.configs.response.PaginatedData;
 import trinity.play2learn.backend.user.models.User;
 
 public interface IActivityApprovedListPaginatedService {
-    
-    PaginatedData<ActivityStudentApprovedResponseDto> cu69ListApprovedActivitiesPaginated(
+
+    PaginatedData<ActivityStudentStateResponseDto> cu69ListApprovedActivitiesPaginated(
             int page,
             int size,
             String orderBy,
@@ -16,6 +16,5 @@ public interface IActivityApprovedListPaginatedService {
             String search,
             List<String> filters,
             List<String> filterValues,
-            User user
-        );
+            User user);
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCreateApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCreateApprovedDtosService.java
@@ -2,11 +2,11 @@ package trinity.play2learn.backend.activity.activity.services.interfaces;
 
 import java.util.List;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.admin.student.models.Student;
 
 public interface IActivityCreateApprovedDtosService {
-    
-    List<ActivityStudentApprovedResponseDto> createApprovedDtos(List<Activity> activities, Student student);
+
+    List<ActivityStudentStateResponseDto> createApprovedDtos(List<Activity> activities, Student student);
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListApproveByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListApproveByStudentService.java
@@ -2,10 +2,10 @@ package trinity.play2learn.backend.activity.activity.services.interfaces;
 
 import java.util.List;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.user.models.User;
 
 public interface IActivityListApproveByStudentService {
-    
-    List<ActivityStudentApprovedResponseDto> cu63ListApprovedActivitiesByStudent(User user);
+
+    List<ActivityStudentStateResponseDto> cu63ListApprovedActivitiesByStudent(User user);
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListPendingPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityListPendingPaginatedService.java
@@ -1,0 +1,19 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+
+public interface IActivityListPendingPaginatedService {
+
+    PaginatedData<ActivityStudentStateResponseDto> cu131ListPendingActivitiesByStudentPaginated(
+            int page,
+            int size,
+            String orderBy,
+            String orderType,
+            String search,
+            List<String> filters,
+            List<String> filterValues,
+            User user);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityApprovedListPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityApprovedListPaginatedService.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.repositories.IActivityPaginatedRepository;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityApprovedListPaginatedService;
@@ -34,7 +34,7 @@ public class ActivityApprovedListPaginatedService implements IActivityApprovedLi
 
     @Override
     @Transactional(readOnly = true)
-    public PaginatedData<ActivityStudentApprovedResponseDto> cu69ListApprovedActivitiesPaginated(int page, int size,
+    public PaginatedData<ActivityStudentStateResponseDto> cu69ListApprovedActivitiesPaginated(int page, int size,
             String orderBy, String orderType, String search, List<String> filters, List<String> filterValues,
             User user) {
 
@@ -74,7 +74,7 @@ public class ActivityApprovedListPaginatedService implements IActivityApprovedLi
 
         Page<Activity> pageResult = activityPaginatedRepository.findAll(spec, pageable);
 
-        List<ActivityStudentApprovedResponseDto> dtos = activityCreateApprovedDtosService
+        List<ActivityStudentStateResponseDto> dtos = activityCreateApprovedDtosService
                 .createApprovedDtos(pageResult.getContent(), student);
 
         return PaginationHelper.fromPage(pageResult, dtos);

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityListApprovedByStudentService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityListApprovedByStudentService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.AllArgsConstructor;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
@@ -17,21 +17,22 @@ import trinity.play2learn.backend.user.models.User;
 @Service
 @AllArgsConstructor
 public class ActivityListApprovedByStudentService implements IActivityListApproveByStudentService {
-    
+
     private final IStudentGetByEmailService studentGetByEmailService;
     private final IActivityGetByStudentService activityGetByStudentService;
     private final IActivityCreateApprovedDtosService activityCreateApprovedDtosService;
 
     @Override
     @Transactional(readOnly = true)
-    public List<ActivityStudentApprovedResponseDto> cu63ListApprovedActivitiesByStudent(User user) {
-        
+    public List<ActivityStudentStateResponseDto> cu63ListApprovedActivitiesByStudent(User user) {
+
         Student student = studentGetByEmailService.getByEmail(user.getEmail());
 
-        //Obtengo todas las actividades del estudiante segun las materias a las que esta asignado
+        // Obtengo todas las actividades del estudiante segun las materias a las que
+        // esta asignado
         List<Activity> activities = activityGetByStudentService.getByStudent(student);
 
         return activityCreateApprovedDtosService.createApprovedDtos(activities, student);
     }
-    
+
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityListPendingPaginatedService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/student/ActivityListPendingPaginatedService.java
@@ -1,0 +1,74 @@
+package trinity.play2learn.backend.activity.activity.services.student;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
+import trinity.play2learn.backend.activity.activity.mappers.ActivityMapper;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListPendingPaginatedService;
+import trinity.play2learn.backend.activity.activity.specs.ActivityCompletedSpecs;
+import trinity.play2learn.backend.activity.activity.specs.ActivitySpecs;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByEmailService;
+import trinity.play2learn.backend.configs.response.PaginatedData;
+import trinity.play2learn.backend.user.models.User;
+import trinity.play2learn.backend.utils.PaginationHelper;
+import trinity.play2learn.backend.utils.PaginatorUtils;
+
+@Service
+@AllArgsConstructor
+public class ActivityListPendingPaginatedService implements IActivityListPendingPaginatedService {
+
+    private final IStudentGetByEmailService studentGetByEmailService;
+
+    private final IActivityCompletedRepository activityCompletedRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedData<ActivityStudentStateResponseDto> cu131ListPendingActivitiesByStudentPaginated(
+            int page,
+            int size,
+            String orderBy,
+            String orderType,
+            String search,
+            List<String> filters,
+            List<String> filterValues,
+            User user) {
+        Student student = studentGetByEmailService.getByEmail(user.getEmail());
+
+        Pageable pageable = PaginatorUtils.buildPageable(page, size, orderBy, orderType);
+
+        Specification<ActivityCompleted> spec = Specification.where(ActivityCompletedSpecs.filterByStudent(student));
+        spec = spec.and(ActivityCompletedSpecs.filterByState(ActivityCompletedState.PENDING));
+
+        if (search != null && !search.isBlank()) {
+            spec = spec.and(ActivityCompletedSpecs.nameContains(search));
+        }
+
+        if (filters != null && filterValues != null && filters.size() == filterValues.size()) {
+            for (int i = 0; i < filters.size(); i++) {
+                String field = filters.get(i);
+                String value = filterValues.get(i);
+                spec = spec.and(ActivityCompletedSpecs.genericFilter(field, value));
+            }
+        }
+
+        Page<ActivityCompleted> pageResult = activityCompletedRepository.findAll(spec, pageable);
+
+        List<ActivityStudentStateResponseDto> dtos = pageResult.getContent().stream()
+                .map(activityCompleted -> ActivityMapper.toStudentStateDto(activityCompleted.getActivity(),
+                        activityCompleted.getRemainingAttempts(), 0.0,
+                        activityCompleted.getCompletedAt(), activityCompleted.getState()))
+                .collect(Collectors.toList());
+
+        return PaginationHelper.fromPage(pageResult, dtos);
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/teacher/ActivityCompletedListPendingService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/teacher/ActivityCompletedListPendingService.java
@@ -37,7 +37,7 @@ public class ActivityCompletedListPendingService implements IActivityCompletedLi
 
         Teacher teacher = teacherGetByEmailService.getByEmail(user.getEmail());
 
-        //Trae todas las actividades completadas cuya actividad pertenezca a un docente
+        //Trae todas las actividades completadas cuya materia pertenezca a un docente
         List<ActivityCompleted> pendingActivitiesCompleted = activityCompletedRepository.findByStateAndActivity_Subject_Teacher(
             ActivityCompletedState.PENDING, teacher);
         

--- a/src/main/java/trinity/play2learn/backend/activity/activity/specs/ActivityCompletedSpecs.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/specs/ActivityCompletedSpecs.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.teacher.models.Teacher;
 
 public class ActivityCompletedSpecs {
@@ -15,6 +16,10 @@ public class ActivityCompletedSpecs {
 
     public static Specification<ActivityCompleted> filterByTeacher(Teacher teacher) {
         return (root, query, cb) -> cb.equal(root.get("activity").get("subject").get("teacher"), teacher);
+    }
+
+    public static Specification<ActivityCompleted> filterByStudent(Student student) {
+        return (root, query, cb) -> cb.equal(root.get("student"), student);
     }
 
     public static Specification<ActivityCompleted> filterByState(ActivityCompletedState state) {

--- a/src/test/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentControllerTest.java
+++ b/src/test/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListByStudentControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListApproveByStudentService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityListNotApprovedByStudentService;
@@ -45,18 +45,16 @@ class ActivityListByStudentControllerTest {
     private IActivityListApproveByStudentService activityListApproveByStudentService;
 
     private List<ActivityStudentNotApprovedResponseDto> notApprovedResponses;
-    private List<ActivityStudentApprovedResponseDto> approvedResponses;
+    private List<ActivityStudentStateResponseDto> approvedResponses;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ActivityListByStudentController(
-                    activityListNotApprovedByStudentService,
-                    activityListApproveByStudentService
-                )
-            )
-            .setControllerAdvice(new GlobalExceptionHandler(null))
-            .build();
+                        activityListNotApprovedByStudentService,
+                        activityListApproveByStudentService))
+                .setControllerAdvice(new GlobalExceptionHandler(null))
+                .build();
 
         notApprovedResponses = buildNotApprovedResponses();
         approvedResponses = buildApprovedResponses();
@@ -66,27 +64,25 @@ class ActivityListByStudentControllerTest {
 
     private List<ActivityStudentNotApprovedResponseDto> buildNotApprovedResponses() {
         return List.of(
-            ActivityStudentNotApprovedResponseDto.builder()
-                .id(1L)
-                .name("Ahorcado")
-                .remainingAttempts(2)
-                .build(),
-            ActivityStudentNotApprovedResponseDto.builder()
-                .id(2L)
-                .name("Preguntados")
-                .remainingAttempts(1)
-                .build()
-        );
+                ActivityStudentNotApprovedResponseDto.builder()
+                        .id(1L)
+                        .name("Ahorcado")
+                        .remainingAttempts(2)
+                        .build(),
+                ActivityStudentNotApprovedResponseDto.builder()
+                        .id(2L)
+                        .name("Preguntados")
+                        .remainingAttempts(1)
+                        .build());
     }
 
-    private List<ActivityStudentApprovedResponseDto> buildApprovedResponses() {
+    private List<ActivityStudentStateResponseDto> buildApprovedResponses() {
         return List.of(
-            ActivityStudentApprovedResponseDto.builder()
-                .id(3L)
-                .name("Ahorcado")
-                .reward(50.0)
-                .build()
-        );
+                ActivityStudentStateResponseDto.builder()
+                        .id(3L)
+                        .name("Ahorcado")
+                        .reward(50.0)
+                        .build());
     }
 
     @Nested
@@ -98,21 +94,19 @@ class ActivityListByStudentControllerTest {
         void shouldReturnNotApprovedActivities() throws Exception {
             // Given
             when(activityListNotApprovedByStudentService.cu62ListNotApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(notApprovedResponses);
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(notApprovedResponses);
 
             // When & Then
             performGetNotApproved()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].id").value(1L))
-                .andExpect(jsonPath("$.data[0].name").value("Ahorcado"))
-                .andExpect(jsonPath("$.data[1].id").value(2L))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].id").value(1L))
+                    .andExpect(jsonPath("$.data[0].name").value("Ahorcado"))
+                    .andExpect(jsonPath("$.data[1].id").value(2L))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityListNotApprovedByStudentService).cu62ListNotApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
 
         @Test
@@ -120,18 +114,16 @@ class ActivityListByStudentControllerTest {
         void shouldReturnEmptyNotApprovedList() throws Exception {
             // Given
             when(activityListNotApprovedByStudentService.cu62ListNotApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(new ArrayList<>());
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(new ArrayList<>());
 
             // When & Then
             performGetNotApproved()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(0))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(0))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityListNotApprovedByStudentService).cu62ListNotApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
     }
 
@@ -144,21 +136,19 @@ class ActivityListByStudentControllerTest {
         void shouldReturnApprovedActivities() throws Exception {
             // Given
             when(activityListApproveByStudentService.cu63ListApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(approvedResponses);
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(approvedResponses);
 
             // When & Then
             performGetApproved()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].id").value(3L))
-                .andExpect(jsonPath("$.data[0].name").value("Ahorcado"))
-                .andExpect(jsonPath("$.data[0].reward").value(50.0))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(1))
+                    .andExpect(jsonPath("$.data[0].id").value(3L))
+                    .andExpect(jsonPath("$.data[0].name").value("Ahorcado"))
+                    .andExpect(jsonPath("$.data[0].reward").value(50.0))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityListApproveByStudentService).cu63ListApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
 
         @Test
@@ -166,18 +156,16 @@ class ActivityListByStudentControllerTest {
         void shouldReturnEmptyApprovedList() throws Exception {
             // Given
             when(activityListApproveByStudentService.cu63ListApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(new ArrayList<>());
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(new ArrayList<>());
 
             // When & Then
             performGetApproved()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(0))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(0))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityListApproveByStudentService).cu63ListApprovedActivitiesByStudent(
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
     }
 
@@ -189,4 +177,3 @@ class ActivityListByStudentControllerTest {
         return mockMvc.perform(get(APPROVED_PATH));
     }
 }
-

--- a/src/test/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentControllerTest.java
+++ b/src/test/java/trinity/play2learn/backend/activity/activity/controllers/ActivityListPaginatedByStudentControllerTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentNotApprovedResponseDto;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityApprovedListPaginatedService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityNotApprovedListPaginatedService;
@@ -47,18 +47,16 @@ class ActivityListPaginatedByStudentControllerTest {
     private IActivityApprovedListPaginatedService activityApprovedListPaginatedService;
 
     private PaginatedData<ActivityStudentNotApprovedResponseDto> notApprovedPaginated;
-    private PaginatedData<ActivityStudentApprovedResponseDto> approvedPaginated;
+    private PaginatedData<ActivityStudentStateResponseDto> approvedPaginated;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(
                 new ActivityListPaginatedByStudentController(
-                    activityNotApprovedListPaginatedService,
-                    activityApprovedListPaginatedService
-                )
-            )
-            .setControllerAdvice(new GlobalExceptionHandler(null))
-            .build();
+                        activityNotApprovedListPaginatedService,
+                        activityApprovedListPaginatedService))
+                .setControllerAdvice(new GlobalExceptionHandler(null))
+                .build();
 
         notApprovedPaginated = buildNotApprovedPaginated();
         approvedPaginated = buildApprovedPaginated();
@@ -68,34 +66,32 @@ class ActivityListPaginatedByStudentControllerTest {
 
     private PaginatedData<ActivityStudentNotApprovedResponseDto> buildNotApprovedPaginated() {
         List<ActivityStudentNotApprovedResponseDto> content = List.of(
-            ActivityStudentNotApprovedResponseDto.builder()
-                .id(1L)
-                .name("Ahorcado")
-                .remainingAttempts(2)
-                .build()
-        );
+                ActivityStudentNotApprovedResponseDto.builder()
+                        .id(1L)
+                        .name("Ahorcado")
+                        .remainingAttempts(2)
+                        .build());
         return buildPaginatedData(content, 1);
     }
 
-    private PaginatedData<ActivityStudentApprovedResponseDto> buildApprovedPaginated() {
-        List<ActivityStudentApprovedResponseDto> content = List.of(
-            ActivityStudentApprovedResponseDto.builder()
-                .id(2L)
-                .name("Preguntados")
-                .reward(50.0)
-                .build()
-        );
+    private PaginatedData<ActivityStudentStateResponseDto> buildApprovedPaginated() {
+        List<ActivityStudentStateResponseDto> content = List.of(
+                ActivityStudentStateResponseDto.builder()
+                        .id(2L)
+                        .name("Preguntados")
+                        .reward(50.0)
+                        .build());
         return buildPaginatedData(content, 1);
     }
 
     private <T> PaginatedData<T> buildPaginatedData(List<T> content, int count) {
         return PaginatedData.<T>builder()
-            .results(content)
-            .count(count)
-            .currentPage(PAGE)
-            .totalPages(1)
-            .pageSize(PAGE_SIZE)
-            .build();
+                .results(content)
+                .count(count)
+                .currentPage(PAGE)
+                .totalPages(1)
+                .pageSize(PAGE_SIZE)
+                .build();
     }
 
     @Nested
@@ -107,37 +103,35 @@ class ActivityListPaginatedByStudentControllerTest {
         void shouldReturnNotApprovedActivitiesPaginated() throws Exception {
             // Given
             when(activityNotApprovedListPaginatedService.cu66listNotApprovedActivitiesPaginated(
-                org.mockito.ArgumentMatchers.eq(PAGE),
-                org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(notApprovedPaginated);
+                    org.mockito.ArgumentMatchers.eq(PAGE),
+                    org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(notApprovedPaginated);
 
             // When & Then
             performGetNotApprovedPaginated()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.count").value(1))
-                .andExpect(jsonPath("$.data.currentPage").value(PAGE))
-                .andExpect(jsonPath("$.data.totalPages").value(1))
-                .andExpect(jsonPath("$.data.pageSize").value(PAGE_SIZE))
-                .andExpect(jsonPath("$.data.results.length()").value(1))
-                .andExpect(jsonPath("$.data.results[0].id").value(1L))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.count").value(1))
+                    .andExpect(jsonPath("$.data.currentPage").value(PAGE))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.pageSize").value(PAGE_SIZE))
+                    .andExpect(jsonPath("$.data.results.length()").value(1))
+                    .andExpect(jsonPath("$.data.results[0].id").value(1L))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityNotApprovedListPaginatedService).cu66listNotApprovedActivitiesPaginated(
-                org.mockito.ArgumentMatchers.eq(PAGE),
-                org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.eq(PAGE),
+                    org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
     }
 
@@ -150,51 +144,48 @@ class ActivityListPaginatedByStudentControllerTest {
         void shouldReturnApprovedActivitiesPaginated() throws Exception {
             // Given
             when(activityApprovedListPaginatedService.cu69ListApprovedActivitiesPaginated(
-                org.mockito.ArgumentMatchers.eq(PAGE),
-                org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(User.class)
-            )).thenReturn(approvedPaginated);
+                    org.mockito.ArgumentMatchers.eq(PAGE),
+                    org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(User.class))).thenReturn(approvedPaginated);
 
             // When & Then
             performGetApprovedPaginated()
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.count").value(1))
-                .andExpect(jsonPath("$.data.currentPage").value(PAGE))
-                .andExpect(jsonPath("$.data.totalPages").value(1))
-                .andExpect(jsonPath("$.data.pageSize").value(PAGE_SIZE))
-                .andExpect(jsonPath("$.data.results.length()").value(1))
-                .andExpect(jsonPath("$.data.results[0].id").value(2L))
-                .andExpect(jsonPath("$.data.results[0].reward").value(50.0))
-                .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.count").value(1))
+                    .andExpect(jsonPath("$.data.currentPage").value(PAGE))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.pageSize").value(PAGE_SIZE))
+                    .andExpect(jsonPath("$.data.results.length()").value(1))
+                    .andExpect(jsonPath("$.data.results[0].id").value(2L))
+                    .andExpect(jsonPath("$.data.results[0].reward").value(50.0))
+                    .andExpect(jsonPath("$.message").value(SuccessfulMessages.okSuccessfully()));
 
             verify(activityApprovedListPaginatedService).cu69ListApprovedActivitiesPaginated(
-                org.mockito.ArgumentMatchers.eq(PAGE),
-                org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.anyString(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(),
-                org.mockito.ArgumentMatchers.any(User.class)
-            );
+                    org.mockito.ArgumentMatchers.eq(PAGE),
+                    org.mockito.ArgumentMatchers.eq(PAGE_SIZE),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.anyString(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(),
+                    org.mockito.ArgumentMatchers.any(User.class));
         }
     }
 
     private ResultActions performGetNotApprovedPaginated() throws Exception {
         return mockMvc.perform(get(NOT_APPROVED_PATH)
-            .param("page", String.valueOf(PAGE))
-            .param("page_size", String.valueOf(PAGE_SIZE)));
+                .param("page", String.valueOf(PAGE))
+                .param("page_size", String.valueOf(PAGE_SIZE)));
     }
 
     private ResultActions performGetApprovedPaginated() throws Exception {
         return mockMvc.perform(get(APPROVED_PATH)
-            .param("page", String.valueOf(PAGE))
-            .param("page_size", String.valueOf(PAGE_SIZE)));
+                .param("page", String.valueOf(PAGE))
+                .param("page_size", String.valueOf(PAGE_SIZE)));
     }
 }
-

--- a/src/test/java/trinity/play2learn/backend/activity/activity/services/ActivityApprovedListPaginatedServiceTest.java
+++ b/src/test/java/trinity/play2learn/backend/activity/activity/services/ActivityApprovedListPaginatedServiceTest.java
@@ -25,7 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
 import trinity.play2learn.backend.activity.activity.ActivityTestMother;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.repositories.IActivityPaginatedRepository;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
@@ -63,12 +63,11 @@ class ActivityApprovedListPaginatedServiceTest {
     @BeforeEach
     void setUp() {
         activityApprovedListPaginatedService = new ActivityApprovedListPaginatedService(
-            studentGetByEmailService,
-            activityGetByStudentService,
-            activityFilterApprovedService,
-            activityPaginatedRepository,
-            activityCreateApprovedDtosService
-        );
+                studentGetByEmailService,
+                activityGetByStudentService,
+                activityFilterApprovedService,
+                activityPaginatedRepository,
+                activityCreateApprovedDtosService);
     }
 
     @Nested
@@ -80,67 +79,67 @@ class ActivityApprovedListPaginatedServiceTest {
         @DisplayName("Given student with approved activities When listing paginated Then returns paginated data with approved activities")
         void whenApprovedActivitiesExist_returnsPaginatedData() {
             User user = ActivityTestMother.studentUser(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            
+            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID,
+                    ActivityTestMother.STUDENT_EMAIL);
+
             List<Activity> allActivities = List.of(
-                ActivityTestMother.ahorcadoActivity(1L),
-                ActivityTestMother.ahorcadoActivity(2L),
-                ActivityTestMother.ahorcadoActivity(3L)
-            );
-            
+                    ActivityTestMother.ahorcadoActivity(1L),
+                    ActivityTestMother.ahorcadoActivity(2L),
+                    ActivityTestMother.ahorcadoActivity(3L));
+
             List<Activity> approvedActivities = List.of(
-                ActivityTestMother.ahorcadoActivity(1L),
-                ActivityTestMother.ahorcadoActivity(2L)
-            );
-            
+                    ActivityTestMother.ahorcadoActivity(1L),
+                    ActivityTestMother.ahorcadoActivity(2L));
+
             Page<Activity> pageResult = buildPage(approvedActivities, 0, SIZE, 2);
             Pageable pageable = pageResult.getPageable();
-            
-            List<ActivityStudentApprovedResponseDto> dtos = List.of(
-                ActivityStudentApprovedResponseDto.builder()
-                    .id(1L)
-                    .name("Ahorcado")
-                    .build(),
-                ActivityStudentApprovedResponseDto.builder()
-                    .id(2L)
-                    .name("Ahorcado")
-                    .build()
-            );
-            PaginatedData<ActivityStudentApprovedResponseDto> expected = buildPaginated(dtos, 2, 1, 1, SIZE);
+
+            List<ActivityStudentStateResponseDto> dtos = List.of(
+                    ActivityStudentStateResponseDto.builder()
+                            .id(1L)
+                            .name("Ahorcado")
+                            .build(),
+                    ActivityStudentStateResponseDto.builder()
+                            .id(2L)
+                            .name("Ahorcado")
+                            .build());
+            PaginatedData<ActivityStudentStateResponseDto> expected = buildPaginated(dtos, 2, 1, 1, SIZE);
 
             when(studentGetByEmailService.getByEmail(ActivityTestMother.STUDENT_EMAIL)).thenReturn(student);
             when(activityGetByStudentService.getByStudent(student)).thenReturn(allActivities);
             when(activityFilterApprovedService.filterByApproved(allActivities, student)).thenReturn(approvedActivities);
-            
+
             try (MockedStatic<PaginatorUtils> paginatorMock = org.mockito.Mockito.mockStatic(PaginatorUtils.class);
-                 MockedStatic<PaginationHelper> paginationMock = org.mockito.Mockito.mockStatic(PaginationHelper.class)) {
+                    MockedStatic<PaginationHelper> paginationMock = org.mockito.Mockito
+                            .mockStatic(PaginationHelper.class)) {
 
                 paginatorMock.when(() -> PaginatorUtils.buildPageable(PAGE, SIZE, ORDER_BY, ORDER_TYPE))
-                    .thenReturn(pageable);
-                when(activityPaginatedRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(pageResult);
+                        .thenReturn(pageable);
+                when(activityPaginatedRepository.findAll(any(Specification.class), eq(pageable)))
+                        .thenReturn(pageResult);
                 when(activityCreateApprovedDtosService.createApprovedDtos(pageResult.getContent(), student))
-                    .thenReturn(dtos);
+                        .thenReturn(dtos);
                 paginationMock.when(() -> PaginationHelper.fromPage(pageResult, dtos)).thenReturn(expected);
 
-                PaginatedData<ActivityStudentApprovedResponseDto> result = activityApprovedListPaginatedService
-                    .cu69ListApprovedActivitiesPaginated(PAGE, SIZE, ORDER_BY, ORDER_TYPE, null, null, null, user);
+                PaginatedData<ActivityStudentStateResponseDto> result = activityApprovedListPaginatedService
+                        .cu69ListApprovedActivitiesPaginated(PAGE, SIZE, ORDER_BY, ORDER_TYPE, null, null, null, user);
 
                 verify(studentGetByEmailService).getByEmail(ActivityTestMother.STUDENT_EMAIL);
                 verify(activityGetByStudentService).getByStudent(student);
                 verify(activityFilterApprovedService).filterByApproved(allActivities, student);
-                
+
                 ArgumentCaptor<Specification<Activity>> specCaptor = createSpecificationCaptor();
                 verify(activityPaginatedRepository).findAll(specCaptor.capture(), eq(pageable));
 
                 assertThat(result)
-                    .isNotNull()
-                    .extracting(PaginatedData::getCount, PaginatedData::getTotalPages)
-                    .containsExactly(2, 1);
-                
+                        .isNotNull()
+                        .extracting(PaginatedData::getCount, PaginatedData::getTotalPages)
+                        .containsExactly(2, 1);
+
                 assertThat(result.getResults())
-                    .hasSize(2)
-                    .extracting(ActivityStudentApprovedResponseDto::getId)
-                    .containsExactly(1L, 2L);
+                        .hasSize(2)
+                        .extracting(ActivityStudentStateResponseDto::getId)
+                        .containsExactly(1L, 2L);
             }
         }
 
@@ -149,33 +148,36 @@ class ActivityApprovedListPaginatedServiceTest {
         @DisplayName("Given student with no approved activities When listing paginated Then returns empty page")
         void whenNoApprovedActivities_returnsEmptyPage() {
             User user = ActivityTestMother.studentUser(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
+            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID,
+                    ActivityTestMother.STUDENT_EMAIL);
             List<Activity> allActivities = List.of(ActivityTestMother.ahorcadoActivity(1L));
             List<Activity> emptyApproved = new ArrayList<>();
             Pageable pageable = PageRequest.of(0, SIZE);
-            PaginatedData<ActivityStudentApprovedResponseDto> expected = buildPaginated(List.of(), 0, 0, 1, SIZE);
+            PaginatedData<ActivityStudentStateResponseDto> expected = buildPaginated(List.of(), 0, 0, 1, SIZE);
 
             when(studentGetByEmailService.getByEmail(ActivityTestMother.STUDENT_EMAIL)).thenReturn(student);
             when(activityGetByStudentService.getByStudent(student)).thenReturn(allActivities);
             when(activityFilterApprovedService.filterByApproved(allActivities, student)).thenReturn(emptyApproved);
-            
+
             try (MockedStatic<PaginatorUtils> paginatorMock = org.mockito.Mockito.mockStatic(PaginatorUtils.class);
-                 MockedStatic<PaginationHelper> paginationMock = org.mockito.Mockito.mockStatic(PaginationHelper.class)) {
+                    MockedStatic<PaginationHelper> paginationMock = org.mockito.Mockito
+                            .mockStatic(PaginationHelper.class)) {
 
                 paginatorMock.when(() -> PaginatorUtils.buildPageable(PAGE, SIZE, ORDER_BY, ORDER_TYPE))
-                    .thenReturn(pageable);
+                        .thenReturn(pageable);
                 paginationMock.when(() -> PaginationHelper.fromPage(Page.empty(pageable), List.of()))
-                    .thenReturn(expected);
+                        .thenReturn(expected);
 
-                PaginatedData<ActivityStudentApprovedResponseDto> result = activityApprovedListPaginatedService
-                    .cu69ListApprovedActivitiesPaginated(PAGE, SIZE, ORDER_BY, ORDER_TYPE, null, null, null, user);
+                PaginatedData<ActivityStudentStateResponseDto> result = activityApprovedListPaginatedService
+                        .cu69ListApprovedActivitiesPaginated(PAGE, SIZE, ORDER_BY, ORDER_TYPE, null, null, null, user);
 
-                verify(activityPaginatedRepository, org.mockito.Mockito.never()).findAll(any(Specification.class), any(Pageable.class));
+                verify(activityPaginatedRepository, org.mockito.Mockito.never()).findAll(any(Specification.class),
+                        any(Pageable.class));
                 assertThat(result)
-                    .isNotNull()
-                    .extracting(PaginatedData::getCount, PaginatedData::getTotalPages)
-                    .containsExactly(0, 0);
-                
+                        .isNotNull()
+                        .extracting(PaginatedData::getCount, PaginatedData::getTotalPages)
+                        .containsExactly(0, 0);
+
                 assertThat(result.getResults()).isEmpty();
             }
         }
@@ -185,20 +187,19 @@ class ActivityApprovedListPaginatedServiceTest {
         return new PageImpl<>(content, PageRequest.of(pageNumber, pageSize), totalElements);
     }
 
-    private PaginatedData<ActivityStudentApprovedResponseDto> buildPaginated(
-        List<ActivityStudentApprovedResponseDto> dtos,
-        int count,
-        int totalPages,
-        int currentPage,
-        int pageSize
-    ) {
-        return PaginatedData.<ActivityStudentApprovedResponseDto>builder()
-            .results(dtos)
-            .count(count)
-            .totalPages(totalPages)
-            .currentPage(currentPage)
-            .pageSize(pageSize)
-            .build();
+    private PaginatedData<ActivityStudentStateResponseDto> buildPaginated(
+            List<ActivityStudentStateResponseDto> dtos,
+            int count,
+            int totalPages,
+            int currentPage,
+            int pageSize) {
+        return PaginatedData.<ActivityStudentStateResponseDto>builder()
+                .results(dtos)
+                .count(count)
+                .totalPages(totalPages)
+                .currentPage(currentPage)
+                .pageSize(pageSize)
+                .build();
     }
 
     @SuppressWarnings("unchecked")
@@ -207,4 +208,3 @@ class ActivityApprovedListPaginatedServiceTest {
     }
 
 }
-

--- a/src/test/java/trinity/play2learn/backend/activity/activity/services/ActivityListApprovedByStudentServiceTest.java
+++ b/src/test/java/trinity/play2learn/backend/activity/activity/services/ActivityListApprovedByStudentServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import trinity.play2learn.backend.activity.activity.ActivityTestMother;
-import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentApprovedResponseDto;
+import trinity.play2learn.backend.activity.activity.dtos.activityStudent.ActivityStudentStateResponseDto;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateApprovedDtosService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetByStudentService;
@@ -40,10 +40,9 @@ class ActivityListApprovedByStudentServiceTest {
     @BeforeEach
     void setUp() {
         activityListApprovedByStudentService = new ActivityListApprovedByStudentService(
-            studentGetByEmailService,
-            activityGetByStudentService,
-            activityCreateApprovedDtosService
-        );
+                studentGetByEmailService,
+                activityGetByStudentService,
+                activityCreateApprovedDtosService);
     }
 
     @Nested
@@ -54,59 +53,58 @@ class ActivityListApprovedByStudentServiceTest {
         @DisplayName("Given student with approved activities When listing approved activities Then returns approved DTOs")
         void whenApprovedActivitiesExist_returnsApprovedDtos() {
             User user = ActivityTestMother.studentUser(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            
+            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID,
+                    ActivityTestMother.STUDENT_EMAIL);
+
             List<Activity> activities = List.of(
-                ActivityTestMother.ahorcadoActivity(1L),
-                ActivityTestMother.ahorcadoActivity(2L)
-            );
-            
-            List<ActivityStudentApprovedResponseDto> expectedDtos = List.of(
-                ActivityStudentApprovedResponseDto.builder()
-                    .id(1L)
-                    .name("Ahorcado")
-                    .build(),
-                ActivityStudentApprovedResponseDto.builder()
-                    .id(2L)
-                    .name("Ahorcado")
-                    .build()
-            );
+                    ActivityTestMother.ahorcadoActivity(1L),
+                    ActivityTestMother.ahorcadoActivity(2L));
+
+            List<ActivityStudentStateResponseDto> expectedDtos = List.of(
+                    ActivityStudentStateResponseDto.builder()
+                            .id(1L)
+                            .name("Ahorcado")
+                            .build(),
+                    ActivityStudentStateResponseDto.builder()
+                            .id(2L)
+                            .name("Ahorcado")
+                            .build());
 
             when(studentGetByEmailService.getByEmail(ActivityTestMother.STUDENT_EMAIL)).thenReturn(student);
             when(activityGetByStudentService.getByStudent(student)).thenReturn(activities);
             when(activityCreateApprovedDtosService.createApprovedDtos(activities, student)).thenReturn(expectedDtos);
 
-            List<ActivityStudentApprovedResponseDto> response = 
-                activityListApprovedByStudentService.cu63ListApprovedActivitiesByStudent(user);
+            List<ActivityStudentStateResponseDto> response = activityListApprovedByStudentService
+                    .cu63ListApprovedActivitiesByStudent(user);
 
             verify(studentGetByEmailService).getByEmail(ActivityTestMother.STUDENT_EMAIL);
             verify(activityGetByStudentService).getByStudent(student);
             verify(activityCreateApprovedDtosService).createApprovedDtos(activities, student);
-            
+
             assertThat(response)
-                .isNotNull()
-                .hasSize(2)
-                .extracting(ActivityStudentApprovedResponseDto::getId)
-                .containsExactly(1L, 2L);
+                    .isNotNull()
+                    .hasSize(2)
+                    .extracting(ActivityStudentStateResponseDto::getId)
+                    .containsExactly(1L, 2L);
         }
 
         @Test
         @DisplayName("Given student with no activities When listing approved activities Then returns empty list")
         void whenNoActivities_returnsEmptyList() {
             User user = ActivityTestMother.studentUser(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
-            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID, ActivityTestMother.STUDENT_EMAIL);
+            Student student = ActivityTestMother.student(ActivityTestMother.STUDENT_ID,
+                    ActivityTestMother.STUDENT_EMAIL);
             List<Activity> emptyActivities = new ArrayList<>();
 
             when(studentGetByEmailService.getByEmail(ActivityTestMother.STUDENT_EMAIL)).thenReturn(student);
             when(activityGetByStudentService.getByStudent(student)).thenReturn(emptyActivities);
             when(activityCreateApprovedDtosService.createApprovedDtos(emptyActivities, student))
-                .thenReturn(new ArrayList<>());
+                    .thenReturn(new ArrayList<>());
 
-            List<ActivityStudentApprovedResponseDto> response = 
-                activityListApprovedByStudentService.cu63ListApprovedActivitiesByStudent(user);
+            List<ActivityStudentStateResponseDto> response = activityListApprovedByStudentService
+                    .cu63ListApprovedActivitiesByStudent(user);
 
             assertThat(response).isNotNull().isEmpty();
         }
     }
 }
-


### PR DESCRIPTION
Endpoint que permite a un estudiante listar las actividades pendientes de correcion. Accedido mediante la URI `GET /activity/student/pending/paginated` y devuelve un json como este:
```json
{
    "data": {
        "results": [
            {
                "id": 54,
                "name": "No Ludica",
                "description": "Actividad prueba",
                "difficulty": "MEDIO",
                "subjectId": 2,
                "subjectName": "Lengua",
                "attempts": 5,
                "remainingAttempts": 4,
                "completedAt": "2026-01-05T14:54:06.165003",
                "reward": 0.0,
                "state": "PENDING"
            }
            {
                "id": 68,
                "name": "No Ludica",
                "description": "Historia institucional 2",
                "difficulty": "MEDIO",
                "subjectId": 3,
                "subjectName": "Geografia",
                "attempts": 5,
                "remainingAttempts": 5,
                "completedAt": "2026-01-27T13:47:44.493694",
                "reward": 0.0,
                "state": "PENDING"
            },
...      
        ],
        "count": 4,
        "totalPages": 1,
        "currentPage": 1,
        "pageSize": 10
    },
    "message": "OK",
    "errors": null,
    "timestamp": "2026-01-28T18:34:07.364404400Z"
}