### PR TITLE
feat Bool

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentNotApprovedResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/dtos/activityStudent/ActivityStudentNotApprovedResponseDto.java
@@ -29,4 +29,5 @@ public class ActivityStudentNotApprovedResponseDto {
     private ActivityStatus status; //CREATED, PUBLISHED, EXPIRED
     private Double minReward; //Recompensa minima que le entregara la actividad si la realiza correctamente
     private Double maxReward; //Recompensa maxima que le entregara la actividad si la realiza correctamente
+    private boolean isBeingDone; //Indica si el estudiante esta realizando la actividad
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/mappers/ActivityMapper.java
@@ -17,7 +17,7 @@ public class ActivityMapper {
 
         public static ActivityStudentNotApprovedResponseDto toNotApprovedDto(
                         Activity activity, Integer remainingAttempts,
-                        ActivityStatus status, Double minReward, Double maxReward) {
+                        ActivityStatus status, Double minReward, Double maxReward, boolean isBeingDone) {
 
                 return ActivityStudentNotApprovedResponseDto.builder()
                                 .id(activity.getId())
@@ -34,6 +34,7 @@ public class ActivityMapper {
                                 .status(status)
                                 .minReward(minReward)
                                 .maxReward(maxReward)
+                                .isBeingDone(isBeingDone)
                                 .build();
         }
 

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityCreateNotApprovedDtosService.java
@@ -15,6 +15,7 @@ import trinity.play2learn.backend.activity.activity.services.interfaces.IActivit
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCreateNotApprovedDtosService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetRemainingAttemptsService;
 import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityGetStatusService;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityIsBeingDoneService;
 import trinity.play2learn.backend.admin.student.models.Student;
 
 @Service
@@ -26,6 +27,8 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
     private final IActivityGetStatusService activityGetStatusService;
 
     private final Map<String, IActivityCalculateRewardStrategyService> activityCalculateRewardStrategyServiceMap;
+
+    private final IActivityIsBeingDoneService activityIsBeingDoneService;
 
     @Override
     public List<ActivityStudentNotApprovedResponseDto> createNotApprovedDtos(List<Activity> activities, Student student) {
@@ -44,7 +47,14 @@ public class ActivityCreateNotApprovedDtosService implements IActivityCreateNotA
             
             Double maxReward = Math.floor(rewardStrategyService.execute(activity));
             
-            activitiesDto.add(ActivityMapper.toNotApprovedDto(activity, remainingAttempts, activityStatus, minReward, maxReward));
+            activitiesDto.add(ActivityMapper.toNotApprovedDto(
+                activity, 
+                remainingAttempts, 
+                activityStatus, 
+                minReward, 
+                maxReward, 
+                activityIsBeingDoneService.execute(activity, student)
+            ));
 
         }
 

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityIsBeingDoneService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ActivityIsBeingDoneService.java
@@ -1,0 +1,26 @@
+package trinity.play2learn.backend.activity.activity.services.commons;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityIsBeingDoneService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetLastStartedService;
+
+@Service
+@AllArgsConstructor
+public class ActivityIsBeingDoneService implements IActivityIsBeingDoneService {
+
+    private final IActivityCompletedGetLastStartedService activityCompletedGetLastStartedService;
+
+    @Override
+    public boolean execute(Activity activity, Student student) {
+        Optional<ActivityCompleted> lastStartedInProgress = activityCompletedGetLastStartedService.getLastStartedInProgress(activity, student);
+        return lastStartedInProgress.isPresent();
+    }
+
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityIsBeingDoneService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityIsBeingDoneService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import trinity.play2learn.backend.activity.activity.models.activity.Activity;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IActivityIsBeingDoneService {
+    
+    boolean execute(Activity activity, Student student);
+
+}


### PR DESCRIPTION
Agregue un atributo bool en cada actividad que lista el listado de actividades no aprobadas.
El mismo sirve para que el front pueda avisar al alumno que tiene un intento en progreso de una actividad, ya sea para desactivar el boton de iniciar o para avisar que si inicia se le va a restar el intento en progreso.
{
            "id": 40,
            "name": "Completar oracion",
            "description": "Encontrar la palabra que falta",
            "startDate": "2025-12-06T20:25:00",
            "endDate": "2025-12-19T17:25:00",
            "difficulty": "MEDIO",
            "maxTime": 30,
            "subjectId": 3,
            "subjectName": "Geografia",
            "attempts": 3,
            "remainingAttempts": 3,
            "status": "EXPIRED",
            "minReward": 0.0,
            "maxReward": 735.0,
            **"beingDone": true**
        }