### PR TITLE
fix: Rankings

### DIFF
--- a/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityCompletedRepository.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityCompletedRepository.java
@@ -12,6 +12,7 @@ import trinity.play2learn.backend.activity.activity.models.activityCompleted.Act
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.subject.models.Subject;
 import trinity.play2learn.backend.admin.teacher.models.Teacher;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
 
 public interface IActivityCompletedRepository extends CrudRepository<ActivityCompleted, Long>, JpaSpecificationExecutor<ActivityCompleted> {
 
@@ -99,5 +100,23 @@ public interface IActivityCompletedRepository extends CrudRepository<ActivityCom
             @Param("subject") Subject subject,
             @Param("state") ActivityCompletedState state,
             @Param("student") Student student
+    );
+
+    //Trae la suma de las recompensas de un estudiante por estado (Para el ranking de monedas por institucion y curso) 
+    @Query("SELECT COALESCE(SUM(ac.reward), 0) " +
+           "FROM ActivityCompleted ac " +
+           "WHERE ac.state = :state " +
+           "AND ac.student = :student")
+    Double sumRewardByStateAndStudent(
+            @Param("state") ActivityCompletedState state,
+            @Param("student") Student student
+    );
+
+    @Query("SELECT new trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto(ac.student, SUM(ac.reward)) " +
+       "FROM ActivityCompleted ac " +
+       "WHERE ac.state = :state " +
+       "GROUP BY ac.student")
+    List<StudentWithRewardTotalDto> sumRewardByStateGroupedByStudent(
+        @Param("state") ActivityCompletedState state
     );
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityCompletedRepository.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/repositories/IActivityCompletedRepository.java
@@ -2,15 +2,15 @@ package trinity.play2learn.backend.activity.activity.repositories;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-
+import org.springframework.data.repository.query.Param;
 import trinity.play2learn.backend.activity.activity.models.activity.Activity;
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompleted;
 import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
 import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.subject.models.Subject;
 import trinity.play2learn.backend.admin.teacher.models.Teacher;
 
 public interface IActivityCompletedRepository extends CrudRepository<ActivityCompleted, Long>, JpaSpecificationExecutor<ActivityCompleted> {
@@ -87,5 +87,17 @@ public interface IActivityCompletedRepository extends CrudRepository<ActivityCom
         Activity activity, 
         Student student, 
         ActivityCompletedState state
+    );
+
+    //Trae la suma de las recompensas de un estudiante por materia y estado (Para el ranking de monedas por materia) 
+    @Query("SELECT COALESCE(SUM(ac.reward), 0) " +
+           "FROM ActivityCompleted ac " +
+           "WHERE ac.state = :state " +
+           "AND ac.activity.subject = :subject " +
+           "AND ac.student = :student")
+    Double sumRewardBySubjectAndStateAndStudent(
+            @Param("subject") Subject subject,
+            @Param("state") ActivityCompletedState state,
+            @Param("student") Student student
     );
 }

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ranking/ActivityCompletedGetSubjectTotalRewardService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ranking/ActivityCompletedGetSubjectTotalRewardService.java
@@ -1,0 +1,23 @@
+package trinity.play2learn.backend.activity.activity.services.commons.ranking;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetSubjectTotalRewardService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+
+@Service
+@AllArgsConstructor
+public class ActivityCompletedGetSubjectTotalRewardService implements IActivityCompletedGetSubjectTotalRewardService {
+    
+    private final IActivityCompletedRepository activityCompletedRepository;
+
+    // Trae la suma de las recompensas de un estudiante por materia y estado (Para el ranking de monedas por materia) 
+    @Override
+    public Double getSubjectTotalRewardByStudent(Student student, Subject subject) {
+        return activityCompletedRepository.sumRewardBySubjectAndStateAndStudent(subject, ActivityCompletedState.APPROVED, student);
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ranking/ActivityCompletedGetTotalRewardService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/commons/ranking/ActivityCompletedGetTotalRewardService.java
@@ -1,0 +1,44 @@
+package trinity.play2learn.backend.activity.activity.services.commons.ranking;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.activity.activity.models.activityCompleted.ActivityCompletedState;
+import trinity.play2learn.backend.activity.activity.repositories.IActivityCompletedRepository;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetTotalRewardService;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+
+@Service
+@AllArgsConstructor
+public class ActivityCompletedGetTotalRewardService implements IActivityCompletedGetTotalRewardService {
+
+    private final IActivityCompletedRepository activityCompletedRepository;
+
+    // Trae la suma de las monedas historicas obtenidas por un estudiante (Para el
+    // ranking de monedas por institucion y curso)
+    @Override
+    public Double getTotalRewardByStudent(Student student) {
+        return activityCompletedRepository.sumRewardByStateAndStudent(ActivityCompletedState.APPROVED, student);
+    }
+
+    @Override
+    public List<StudentWithRewardTotalDto> getTotalRewardByStudents(List<Student> students) {
+
+        //Realiza una consulta optimizada a la base de datos para obtener el total de recompensas obtenidas por cada estudiante en una sola consulta.
+        Map<Student, Double> rewardByStudent = activityCompletedRepository
+                .sumRewardByStateGroupedByStudent(ActivityCompletedState.APPROVED)
+                .stream()
+                .collect(Collectors.toMap(
+                        StudentWithRewardTotalDto::getStudent,
+                        StudentWithRewardTotalDto::getTotalReward
+                ));
+
+        //Agrega los que no tienen ninguna actividad con 0.0
+        return students.stream()
+                .map(s -> new StudentWithRewardTotalDto(s, rewardByStudent.getOrDefault(s, 0.0)))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedGetSubjectTotalRewardService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedGetSubjectTotalRewardService.java
@@ -1,0 +1,9 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.subject.models.Subject;
+
+public interface IActivityCompletedGetSubjectTotalRewardService {
+    
+    Double getSubjectTotalRewardByStudent(Student student, Subject subject);
+}

--- a/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedGetTotalRewardService.java
+++ b/src/main/java/trinity/play2learn/backend/activity/activity/services/interfaces/IActivityCompletedGetTotalRewardService.java
@@ -1,0 +1,13 @@
+package trinity.play2learn.backend.activity.activity.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+
+public interface IActivityCompletedGetTotalRewardService {
+
+    Double getTotalRewardByStudent(Student student);
+
+    List<StudentWithRewardTotalDto> getTotalRewardByStudents(List<Student> students);
+}

--- a/src/main/java/trinity/play2learn/backend/admin/student/repositories/IStudentRepository.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/repositories/IStudentRepository.java
@@ -35,5 +35,7 @@ public interface IStudentRepository extends CrudRepository<Student, Long>, JpaSp
     int countByDeletedAtIsNull();
 
     List<Student> findByDeletedAtIsNull();
+
+    List<Student> findAllByDeletedAtIsNull();
 }
 

--- a/src/main/java/trinity/play2learn/backend/admin/student/services/commons/StudentFindAllService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/services/commons/StudentFindAllService.java
@@ -1,0 +1,22 @@
+package trinity.play2learn.backend.admin.student.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.admin.student.repositories.IStudentRepository;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentFindAllService;
+
+@Service
+@AllArgsConstructor
+public class StudentFindAllService implements IStudentFindAllService {
+    
+    private final IStudentRepository studentRepository;
+    
+    @Override
+    public List<Student> findAll() {
+        return studentRepository.findAllByDeletedAtIsNull();
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/admin/student/services/interfaces/IStudentFindAllService.java
+++ b/src/main/java/trinity/play2learn/backend/admin/student/services/interfaces/IStudentFindAllService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.admin.student.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+
+public interface IStudentFindAllService {
+    
+    List<Student> findAll();
+}

--- a/src/main/java/trinity/play2learn/backend/economy/wallet/services/commons/WalletGetTotalRankingService.java
+++ b/src/main/java/trinity/play2learn/backend/economy/wallet/services/commons/WalletGetTotalRankingService.java
@@ -17,6 +17,7 @@ public class WalletGetTotalRankingService implements IWalletGetTotalRakingServic
 
     @Override
     public List<Wallet> execute() {
+        //Trae los 10 wallets con mayor balance total
         return walletRepository.findTop10OrderByTotalBalanceDesc();
     }
     

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/StudentWithRewardTotalDto.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/StudentWithRewardTotalDto.java
@@ -1,0 +1,17 @@
+package trinity.play2learn.backend.profile.ranking.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import trinity.play2learn.backend.admin.student.models.Student;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudentWithRewardTotalDto {
+    
+    private Student student;
+    private Double totalReward; //Total de monedas conseguidas (Puede ser el total o solo de una materia)
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/request/LeaderboardRequestDto.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/request/LeaderboardRequestDto.java
@@ -14,6 +14,5 @@ public class LeaderboardRequestDto {
 
     private LeaderboardType type;
 
-    private Long id;
-    
+    private Long id;    
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/response/LeaderboardResponseDto.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/dtos/response/LeaderboardResponseDto.java
@@ -16,5 +16,6 @@ public class LeaderboardResponseDto {
     private LeaderboardParticipantResponseDto currentUserPosition;
 
     private List<LeaderboardParticipantResponseDto> participants;
-    
+
+    private Integer totalParticipants;
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/mappers/LeaderboardByCoinsMapper.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/mappers/LeaderboardByCoinsMapper.java
@@ -35,11 +35,13 @@ public class LeaderboardByCoinsMapper {
 
     public static LeaderboardResponseDto toDto (
         List<LeaderboardParticipantResponseDto> participants, 
-        LeaderboardParticipantResponseDto currentUserPosition
+        LeaderboardParticipantResponseDto currentUserPosition,
+        Integer totalParticipants
     ) {
         return LeaderboardResponseDto.builder()
             .currentUserPosition(currentUserPosition)
             .participants(participants)
+            .totalParticipants(totalParticipants)
             .build();
     }
 

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/mappers/LeaderboardByCoinsMapper.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/mappers/LeaderboardByCoinsMapper.java
@@ -3,8 +3,10 @@ package trinity.play2learn.backend.profile.ranking.mappers;
 import java.util.ArrayList;
 import java.util.List;
 
+import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.economy.wallet.models.Wallet;
 import trinity.play2learn.backend.profile.avatar.mappers.AspectMapper;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardParticipantResponseDto;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardResponseDto;
 
@@ -39,5 +41,33 @@ public class LeaderboardByCoinsMapper {
             .currentUserPosition(currentUserPosition)
             .participants(participants)
             .build();
+    }
+
+    public static StudentWithRewardTotalDto toStudentWithRewardTotalDto(Student student, Double totalReward) {
+        return StudentWithRewardTotalDto.builder()
+            .student(student)
+            .totalReward(totalReward)
+            .build();
+    }
+
+    public static LeaderboardParticipantResponseDto toParticipantDto(StudentWithRewardTotalDto studentWithRewardTotalDto, Long position) {
+        return LeaderboardParticipantResponseDto.builder()
+            .position(position)
+            .name(studentWithRewardTotalDto.getStudent().getName() + " " + studentWithRewardTotalDto.getStudent().getLastname())
+            .quantity(Math.round((studentWithRewardTotalDto.getTotalReward()) * 100.0) / 100.0)
+            .selectedBody(studentWithRewardTotalDto.getStudent().getProfile().getSelectedBody() != null ? AspectMapper.toSimpleDto(studentWithRewardTotalDto.getStudent().getProfile().getSelectedBody()) : null)
+            .selectedShirt(studentWithRewardTotalDto.getStudent().getProfile().getSelectedShirt() != null ? AspectMapper.toSimpleDto(studentWithRewardTotalDto.getStudent().getProfile().getSelectedShirt()) : null)
+            .selectedHat(studentWithRewardTotalDto.getStudent().getProfile().getSelectedHat() != null ? AspectMapper.toSimpleDto(studentWithRewardTotalDto.getStudent().getProfile().getSelectedHat()) : null)
+            .build();
+    }
+
+    public static List<LeaderboardParticipantResponseDto> toDtoListByStudentWithRewardTotalDto(List<StudentWithRewardTotalDto> studentsWithRewardTotal) {
+        Long position = 1L;
+        List<LeaderboardParticipantResponseDto> participants = new ArrayList<>();
+        for (StudentWithRewardTotalDto studentWithRewardTotal : studentsWithRewardTotal) {
+            participants.add(toParticipantDto(studentWithRewardTotal, position));
+            position++;
+        }
+        return participants;
     }
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsCourseService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsCourseService.java
@@ -1,43 +1,59 @@
 package trinity.play2learn.backend.profile.ranking.services.RankingByCoinsStrategies;
 
 import org.springframework.stereotype.Service;
-
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingByCoinsStrategyService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingFindCoinsDtoService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetStudentPositionService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetTop10StudentsService;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
 import trinity.play2learn.backend.profile.ranking.dtos.request.LeaderboardRequestDto;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetTotalRewardService;
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.student.services.interfaces.IStudentGetByCourseService;
+import java.util.ArrayList;
 import java.util.List;
 import trinity.play2learn.backend.profile.ranking.mappers.LeaderboardByCoinsMapper;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardParticipantResponseDto;
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetRankingByStudentsService;
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetPositionRankingByStudentsService;
 
-@Service ("CURSO")
+@Service("CURSO")
 @AllArgsConstructor
 public class RankingByCoinsCourseService implements IRankingByCoinsStrategyService {
 
     private final IStudentGetByCourseService studentGetByCourseService;
+    private final IActivityCompletedGetTotalRewardService getTotalRewardService;
+    private final IRankingGetTop10StudentsService rankingGetTop10StudentsService;
+    private final IRankingGetStudentPositionService rankingGetStudentPositionService;
+    private final IRankingFindCoinsDtoService rankingFindCoinsDtoService;
 
-    private final IWalletGetRankingByStudentsService walletGetRankingByStudentsService;
-
-    private final IWalletGetPositionRankingByStudentsService walletGetPositionRankingByStudentsService;
-    
     @Override
     public LeaderboardResponseDto execute(LeaderboardRequestDto leaderboardRequestDto, Student student) {
 
         List<Student> students = studentGetByCourseService.getStudentsByCourseId(student.getCourse().getId());
 
-        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoList(
-            walletGetRankingByStudentsService.execute(students)
-        );
+        //Crea un listado de dtos con el estudiante y el total de recompensas acumuladas
+        List<StudentWithRewardTotalDto> studentsWithRewardTotal = new ArrayList<>();
+        for (Student s : students) {
 
-        LeaderboardParticipantResponseDto currentUserPosition = LeaderboardByCoinsMapper.toParticipantDto(
-            student.getWallet(),
-            walletGetPositionRankingByStudentsService.execute(student, students)
-        );
+                //Calcula el total de recompensas acumuladas por el estudiante en las actividades que aprobo
+                Double totalReward = getTotalRewardService.getTotalRewardByStudent(s);
 
-        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition);
+                studentsWithRewardTotal.add(LeaderboardByCoinsMapper.toStudentWithRewardTotalDto(s, totalReward));
+        }
+
+        // Obtiene el top 10 de estudiantes
+        List<StudentWithRewardTotalDto> top10Students = rankingGetTop10StudentsService.getTop10StudentsByCoins(studentsWithRewardTotal);
+
+        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoListByStudentWithRewardTotalDto(top10Students);
+
+        StudentWithRewardTotalDto studentDto = rankingFindCoinsDtoService.findDtoByStudent(studentsWithRewardTotal, student);
+
+        //Obtiene la posicion del estudiante en el ranking
+        Long studentPosition = rankingGetStudentPositionService.getStudentRankingPositionByCoins(studentsWithRewardTotal, studentDto);
+
+        LeaderboardParticipantResponseDto currentUserPosition = LeaderboardByCoinsMapper.toParticipantDto(studentDto, studentPosition);
+
+        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition, students.size());
     }
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsInstitutionService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsInstitutionService.java
@@ -1,16 +1,18 @@
 package trinity.play2learn.backend.profile.ranking.services.RankingByCoinsStrategies;
 
 import java.util.List;
-
 import org.springframework.stereotype.Service;
-
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingByCoinsStrategyService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingFindCoinsDtoService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetStudentPositionService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetTop10StudentsService;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
 import trinity.play2learn.backend.profile.ranking.dtos.request.LeaderboardRequestDto;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetTotalRewardService;
 import trinity.play2learn.backend.admin.student.models.Student;
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetPositionRankingService;
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetTotalRakingService;
+import trinity.play2learn.backend.admin.student.services.interfaces.IStudentFindAllService;
 import trinity.play2learn.backend.profile.ranking.mappers.LeaderboardByCoinsMapper;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardParticipantResponseDto;
 
@@ -18,24 +20,33 @@ import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardParti
 @AllArgsConstructor
 public class RankingByCoinsInstitutionService implements IRankingByCoinsStrategyService {
 
-    private final IWalletGetTotalRakingService walletGetTotalRakingService;
-
-    private final IWalletGetPositionRankingService walletGetPositionRankingService;
-
-
+    private final IActivityCompletedGetTotalRewardService getTotalRewardService;
+    private final IRankingGetTop10StudentsService rankingGetTop10StudentsService;
+    private final IRankingGetStudentPositionService rankingGetStudentPositionService;
+    private final IRankingFindCoinsDtoService rankingFindCoinsDtoService;
+    private final IStudentFindAllService studentFindAllService;
+    
     @Override
     public LeaderboardResponseDto execute(LeaderboardRequestDto leaderboardRequestDto, Student student) {
 
-        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoList(
-            walletGetTotalRakingService.execute()
-        );
+        // //Trae todos los estudiantes activos. Si agregamos la clase Institucion habria que cambiar este metodo
+        List<Student> students = studentFindAllService.findAll();
 
-        LeaderboardParticipantResponseDto currentUserPosition = LeaderboardByCoinsMapper.toParticipantDto(
-            student.getWallet(),
-            walletGetPositionRankingService.execute(student)
-        );
+        //La BD trae todos los estudiantes con sus recompensas acumuladas en una sola consulta (optimizacion)
+        List<StudentWithRewardTotalDto> studentsWithRewardTotal = getTotalRewardService.getTotalRewardByStudents(students);
 
-        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition);
+        // Obtiene el top 10 de estudiantes
+        List<StudentWithRewardTotalDto> top10Students = rankingGetTop10StudentsService.getTop10StudentsByCoins(studentsWithRewardTotal);
+
+        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoListByStudentWithRewardTotalDto(top10Students);
+
+        StudentWithRewardTotalDto studentDto = rankingFindCoinsDtoService.findDtoByStudent(studentsWithRewardTotal, student);
+
+        //Obtiene la posicion del estudiante en el ranking
+        Long studentPosition = rankingGetStudentPositionService.getStudentRankingPositionByCoins(studentsWithRewardTotal, studentDto);
+
+        LeaderboardParticipantResponseDto currentUserPosition = LeaderboardByCoinsMapper.toParticipantDto(studentDto, studentPosition);
+
+        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition, students.size());
     }
-    
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsSubjectService.java
@@ -1,34 +1,32 @@
 package trinity.play2learn.backend.profile.ranking.services.RankingByCoinsStrategies;
 
 import org.springframework.stereotype.Service;
-
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingByCoinsStrategyService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetStudentPositionService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetTop10StudentsService;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
 import trinity.play2learn.backend.profile.ranking.dtos.request.LeaderboardRequestDto;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardResponseDto;
+import trinity.play2learn.backend.activity.activity.services.interfaces.IActivityCompletedGetSubjectTotalRewardService;
 import trinity.play2learn.backend.admin.student.models.Student;
 import trinity.play2learn.backend.admin.subject.services.interfaces.ISubjectGetByIdService;
 import trinity.play2learn.backend.configs.exceptions.ConflictException;
 import trinity.play2learn.backend.admin.subject.models.Subject;
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetRankingByStudentsService;
+import java.util.ArrayList;
 import java.util.List;
 import trinity.play2learn.backend.profile.ranking.mappers.LeaderboardByCoinsMapper;
 import trinity.play2learn.backend.profile.ranking.dtos.response.LeaderboardParticipantResponseDto;
-
-import trinity.play2learn.backend.economy.wallet.services.interfaces.IWalletGetPositionRankingByStudentsService;
 
 @Service ("MATERIA")    
 @AllArgsConstructor
 public class RankingByCoinsSubjectService implements IRankingByCoinsStrategyService {
     
-
     private final ISubjectGetByIdService subjectGetByIdService;
-
-    private final IWalletGetRankingByStudentsService walletGetRankingByStudentsService;
-
-    private final IWalletGetPositionRankingByStudentsService walletGetPositionRankingByStudentsService;
-
-
+    private final IActivityCompletedGetSubjectTotalRewardService activityCompletedGetSubjectTotalRewardService;
+    private final IRankingGetTop10StudentsService rankingGetTop10StudentsService;
+    private final IRankingGetStudentPositionService rankingGetStudentPositionService;
+    
     @Override
     public LeaderboardResponseDto execute(LeaderboardRequestDto leaderboardRequestDto, Student student) {
 
@@ -42,15 +40,41 @@ public class RankingByCoinsSubjectService implements IRankingByCoinsStrategyServ
             throw new ConflictException("El estudiante no puede ver el ranking de esta materia");
         }
 
-        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoList(
-            walletGetRankingByStudentsService.execute(subject.getStudents())
-        );
+        List<Student> students = subject.getStudents();
+
+        //Crea un listado de dtos con el estudiante y el total de recompensas acumuladas únicamente en esta materia.
+        List<StudentWithRewardTotalDto> studentsWithRewardTotal = new ArrayList<>();
+        for (Student s : students) {
+
+            //Calcula el total de recompensas acumuladas únicamente en esta materia por el estudiante.
+            Double subjectRankingBalance = activityCompletedGetSubjectTotalRewardService.getSubjectTotalRewardByStudent(s, subject);
+
+            studentsWithRewardTotal.add(LeaderboardByCoinsMapper.toStudentWithRewardTotalDto(s, subjectRankingBalance));
+        }
+        
+        //Obtiene el top 10 de estudiantes
+        List<StudentWithRewardTotalDto> top10Students = rankingGetTop10StudentsService.getTop10StudentsByCoins(studentsWithRewardTotal);
+
+        List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoListByStudentWithRewardTotalDto(top10Students);
+
+        StudentWithRewardTotalDto studentDto = findDtoByStudent(studentsWithRewardTotal, student);
+
+        //Obtiene la posicion del estudiante en el ranking
+        Long studentPosition = rankingGetStudentPositionService.getStudentRankingPositionByCoins(studentsWithRewardTotal, studentDto);
 
         LeaderboardParticipantResponseDto currentUserPosition = LeaderboardByCoinsMapper.toParticipantDto(
-            student.getWallet(),
-            walletGetPositionRankingByStudentsService.execute(student, subject.getStudents())
+            studentDto,
+            studentPosition
         );
 
         return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition);
     }
+
+    private StudentWithRewardTotalDto findDtoByStudent(List<StudentWithRewardTotalDto> list, Student targetStudent) {
+    return list.stream()
+        // Filtramos por el ID del estudiante
+        .filter(dto -> dto.getStudent().equals(targetStudent))
+        .findFirst()
+        .orElse(null);
+}
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsSubjectService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/RankingByCoinsStrategies/RankingByCoinsSubjectService.java
@@ -3,6 +3,7 @@ package trinity.play2learn.backend.profile.ranking.services.RankingByCoinsStrate
 import org.springframework.stereotype.Service;
 import lombok.AllArgsConstructor;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingByCoinsStrategyService;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingFindCoinsDtoService;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetStudentPositionService;
 import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetTop10StudentsService;
 import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
@@ -26,6 +27,7 @@ public class RankingByCoinsSubjectService implements IRankingByCoinsStrategyServ
     private final IActivityCompletedGetSubjectTotalRewardService activityCompletedGetSubjectTotalRewardService;
     private final IRankingGetTop10StudentsService rankingGetTop10StudentsService;
     private final IRankingGetStudentPositionService rankingGetStudentPositionService;
+    private final IRankingFindCoinsDtoService rankingFindCoinsDtoService;
     
     @Override
     public LeaderboardResponseDto execute(LeaderboardRequestDto leaderboardRequestDto, Student student) {
@@ -57,7 +59,7 @@ public class RankingByCoinsSubjectService implements IRankingByCoinsStrategyServ
 
         List<LeaderboardParticipantResponseDto> participants = LeaderboardByCoinsMapper.toDtoListByStudentWithRewardTotalDto(top10Students);
 
-        StudentWithRewardTotalDto studentDto = findDtoByStudent(studentsWithRewardTotal, student);
+        StudentWithRewardTotalDto studentDto = rankingFindCoinsDtoService.findDtoByStudent(studentsWithRewardTotal, student);
 
         //Obtiene la posicion del estudiante en el ranking
         Long studentPosition = rankingGetStudentPositionService.getStudentRankingPositionByCoins(studentsWithRewardTotal, studentDto);
@@ -67,14 +69,8 @@ public class RankingByCoinsSubjectService implements IRankingByCoinsStrategyServ
             studentPosition
         );
 
-        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition);
+        return LeaderboardByCoinsMapper.toDto(participants, currentUserPosition, students.size());
     }
 
-    private StudentWithRewardTotalDto findDtoByStudent(List<StudentWithRewardTotalDto> list, Student targetStudent) {
-    return list.stream()
-        // Filtramos por el ID del estudiante
-        .filter(dto -> dto.getStudent().equals(targetStudent))
-        .findFirst()
-        .orElse(null);
-}
+    
 }

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingFindCoinsDtoService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingFindCoinsDtoService.java
@@ -1,0 +1,22 @@
+package trinity.play2learn.backend.profile.ranking.services.commons;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingFindCoinsDtoService;
+
+@Service
+public class RankingFindCoinsDtoService implements IRankingFindCoinsDtoService {
+
+    @Override
+    public StudentWithRewardTotalDto findDtoByStudent(List<StudentWithRewardTotalDto> list, Student targetStudent) {
+    return list.stream()
+        // Filtramos por el ID del estudiante
+        .filter(dto -> dto.getStudent().equals(targetStudent))
+        .findFirst()
+        .orElse(null);
+}
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingGetStudentPositionService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingGetStudentPositionService.java
@@ -1,0 +1,31 @@
+package trinity.play2learn.backend.profile.ranking.services.commons;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetStudentPositionService;
+
+@Service
+public class RankingGetStudentPositionService implements IRankingGetStudentPositionService {
+
+    // Devuelve la posicion del estudiante en el ranking de monedas
+    @Override
+    public Long getStudentRankingPositionByCoins(List<StudentWithRewardTotalDto> list,
+            StudentWithRewardTotalDto targetDto) {
+        // Ordenamos la lista de mayor a menor recompensa
+        List<StudentWithRewardTotalDto> sortedList = list.stream()
+                .sorted(Comparator.comparing(StudentWithRewardTotalDto::getTotalReward).reversed())
+                .collect(Collectors.toList());
+
+        // Buscamos la posición comparando el ID del estudiante dentro del DTO
+        for (int i = 0; i < sortedList.size(); i++) {
+            if (sortedList.get(i).getStudent().getId().equals(targetDto.getStudent().getId())) {
+                return (long) i + 1; // +1 para que empiece en 1
+            }
+        }
+
+        return -1L; // No encontrado
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingGetTop10StudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/commons/RankingGetTop10StudentsService.java
@@ -1,0 +1,25 @@
+package trinity.play2learn.backend.profile.ranking.services.commons;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+import trinity.play2learn.backend.profile.ranking.services.interfaces.IRankingGetTop10StudentsService;
+
+@Service
+public class RankingGetTop10StudentsService implements IRankingGetTop10StudentsService {
+
+    //Devuelve los 10 estudiantes con mayor cantidad de monedas ordenados de forma descendente
+    @Override
+    public List<StudentWithRewardTotalDto> getTop10StudentsByCoins(List<StudentWithRewardTotalDto> students) {
+        return students.stream()
+                // Ordena de forma descendente por totalReward
+                .sorted(Comparator.comparing(StudentWithRewardTotalDto::getTotalReward).reversed())
+                // Toma solo los primeros 10
+                .limit(10)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingFindCoinsDtoService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingFindCoinsDtoService.java
@@ -1,0 +1,12 @@
+package trinity.play2learn.backend.profile.ranking.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.admin.student.models.Student;
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+
+public interface IRankingFindCoinsDtoService {
+    
+    StudentWithRewardTotalDto findDtoByStudent(List<StudentWithRewardTotalDto> dtoList, Student targetStudent);
+    
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingGetStudentPositionService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingGetStudentPositionService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.profile.ranking.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+
+public interface IRankingGetStudentPositionService {
+    
+    public Long getStudentRankingPositionByCoins(List<StudentWithRewardTotalDto> list, StudentWithRewardTotalDto targetDto);
+}

--- a/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingGetTop10StudentsService.java
+++ b/src/main/java/trinity/play2learn/backend/profile/ranking/services/interfaces/IRankingGetTop10StudentsService.java
@@ -1,0 +1,10 @@
+package trinity.play2learn.backend.profile.ranking.services.interfaces;
+
+import java.util.List;
+
+import trinity.play2learn.backend.profile.ranking.dtos.StudentWithRewardTotalDto;
+
+public interface IRankingGetTop10StudentsService {
+    
+    List<StudentWithRewardTotalDto> getTop10StudentsByCoins(List<StudentWithRewardTotalDto> students);
+}


### PR DESCRIPTION
### Ranking por materia
Modifique la estrategia que devuelve el ranking de monedas por materia. Antes se ordenaba a los estudiantes de la materia segun su balance actual. 
Lo modifique para que los ordene segun las monedas totales obtenidas en actividades de la materia. 

### Ranking por curso
Toma todos los estudiantes asignados a un curso. Calcula el total de recompensa obtenida de cada uno y los ordena en un top 10

### Ranking por institucion
En un principio lo hice exactamente igual que el servicio de ranking por curso. El problema era que tardaba una eternidad el endpoint (22 segundos) porque calculaba el total de recompensa del estudiante uno por uno.
El claude me tiro una mega consulta que nadie entiende pero que funciona. Basicamente devuelve un listado de dtos con el estudiante y su total de recompensa. Al hacer todo la BD es mas rapido (Igual tarda 12 segundos, una banda pero es lo que hay)

### Atributo totalParticipants
Tambien agregue atributo `totalParticipants` para mostrar el total de participantes del ranking